### PR TITLE
Improve accessibility with alt text and ARIA labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,18 +12,18 @@
 </head>
 
 <body>
-  <section class="">
+  <section class="" aria-label="Mobile logo section">
     <div class="div-mobil ">
-      <img class="img-acceuil-mobile " src="public/img/disquepluslogo3.png">
+      <img class="img-acceuil-mobile" src="public/img/disquepluslogo3.png" alt="DisquePlus logo">
 
     </div>
 
   </section>
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex" aria-label="Main navigation">
       <div class="bigdiv container-fluid">
         <a class="navbar-brand" href="#">
-          <div class="div-img-acceuil-mobile"></div> <img class="img-acceuil" src="public/img/disquepluslogo3.png">
+          <div class="div-img-acceuil-mobile"></div> <img class="img-acceuil" src="public/img/disquepluslogo3.png" alt="DisquePlus logo">
         </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
           aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -32,10 +32,10 @@
         <div class="collapse navbar-collapse " id="navbarSupportedContent">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
             <li class="nav-item ms-4 link-wrapper">
-              <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="home"
-                    color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36"
+              <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Home" role="img"
+                    color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36"
                     xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link">
-                    <title></title>
+                    <title>Home</title>
                     <path
                       d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z"
                       class="sc-hzDkRC kzwgVO"></path>
@@ -44,11 +44,10 @@
               </a>
             </li>
             <li class="nav-item ms-4 link-wrapper">
-              <a class="nav-link hover-3" aria-current="page" href="public/pages/search/search.html"><span><svg
-                    aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1"
+              <a class="nav-link hover-3" aria-current="page" href="public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1"
                     viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE"
                     class="sc-jhAzac vfaMf svg-nav-link">
-                    <title></title>
+                    <title>Search</title>
                     <path
                       d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z"
                       class="sc-hzDkRC kzwgVO"></path>
@@ -60,10 +59,10 @@
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
             <li class="nav-item ms-4 link-wrapper">
-              <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies"
-                    color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36"
+              <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img"
+                    color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36"
                     xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link">
-                    <title></title>
+                    <title>Movies</title>
                     <path
                       d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838"
                       class="sc-hzDkRC kzwgVO"></path>
@@ -72,10 +71,10 @@
               </a>
             </li>
             <li class="nav-item ms-4 link-wrapper">
-              <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series"
-                    color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36"
+              <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img"
+                    color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36"
                     xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link">
-                    <title></title>
+                    <title>Series</title>
                     <path
                       d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z"
                       class="sc-hzDkRC kzwgVO"></path>
@@ -89,8 +88,8 @@
       </div>
     </nav>
   </header>
-  <main class="mainsection">
-    <section class="sectioncarousel mt-2 mb-5 container-fluid">
+  <main class="mainsection" role="main">
+    <section aria-label="Featured carousel" class="sectioncarousel mt-2 mb-5 container-fluid">
       <div id="carouselExampleIndicators" class="carousel slide " data-bs-ride="true">
         <div class="carousel-indicators">
           <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="0" class="active"
@@ -102,16 +101,16 @@
         </div>
         <div class="carousel-inner">
           <div class="carousel-item active">
-            <img src="public/img/compose.jfif" class="d-block w-100 crouselimg" alt="...">
+            <img src="public/img/compose.jfif" class="d-block w-100 crouselimg" alt="Featured banner 1">
             <!-- <div class="carousel-img d-block w-100 crouselimg"> -->
 
             <!-- </div> -->
           </div>
           <div class="carousel-item">
-            <img src="public/img/compose3.jfif" class="d-block w-100 crouselimg" alt="...">
+            <img src="public/img/compose3.jfif" class="d-block w-100 crouselimg" alt="Featured banner 2">
           </div>
           <div class="carousel-item">
-            <img src="public/img/compose4.jfif" class="d-block w-100 crouselimg" alt="...">
+            <img src="public/img/compose4.jfif" class="d-block w-100 crouselimg" alt="Featured banner 3">
           </div>
         </div>
         <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleIndicators"
@@ -130,42 +129,42 @@
 
 
 
-    <section class=" mb-5 container ">
+    <section class=" mb-5 container" aria-label="Category thumbnails">
 
       <!-- <div class="video-card-container ">
         <div class="video-card" >
-          <img src="public/img/scale1cards.png" class="video-card-image" alt="...">
+          <img src="public/img/scale1cards.png" class="video-card-image" alt="Disney card">
           <video src="public/video/disney.mp4" mute loop class="card-video">
           </video>
         </div> -->
 
       <!-- <div class="video-card-container">
         <div class="video-card">
-          <img src="public/img/scale1cards.png" class="video-card-image" alt="">
+          <img src="public/img/scale1cards.png" class="video-card-image" alt="Disney card">
           <video src="public/video/disney.mp4" mute loop class="card-video"></video>
         </div>
         <div class="video-card">
-          <img src="public/img/scale2cards.png" class="video-card-image" alt="">
+          <img src="public/img/scale2cards.png" class="video-card-image" alt="Pixar card">
           <video src="public/video/pixar.mp4" mute loop class="card-video"></video>
         </div>
         <div class="video-card">
           <a href="public/pages/catepages/marvelpage.html">
             <div>
-              <img src="public/img/scale3cards.png" class="video-card-image" alt="">
+              <img src="public/img/scale3cards.png" class="video-card-image" alt="Marvel card">
               <video src="public/video/marvel.mp4" mute loop onmouseover="play();" onmouseout="pause(); " class="card-video"></video>
             </div>
           </a>
         </div>
         <div class="video-card">
-          <img src="public/img/scale4cards.png" class="video-card-image" alt="">
+          <img src="public/img/scale4cards.png" class="video-card-image" alt="Star Wars card">
           <video src="public/video/star-wars.mp4" mute loop class="card-video"></video>
         </div>
         <div class="video-card">
-          <img src="public/img/scale5cards.png" class="video-card-image" alt="">
+          <img src="public/img/scale5cards.png" class="video-card-image" alt="National Geographic card">
           <video src="public/video/national-geographic.mp4" mute loop class="card-video"></video>
         </div>
         <div class="video-card">
-          <img src="public/img/scale6cards.png" class="video-card-image" alt="">
+          <img src="public/img/scale6cards.png" class="video-card-image" alt="Brand Star card">
           <video src="public/video/brand-star.mp4" mute loop class="card-video"></video>
         </div>
       </div>
@@ -178,9 +177,9 @@
         <div class="item">
           <a href="public/pages/catepages/disney/disneypage.html">
             <div class=item__border>
-              <img class="item__image"
+              <img class="item__image" alt="Category image"
                 src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/FFA0BEBAC1406D88929497501C84019EBBA1B018D3F7C4C3C829F1810A24AD6E/scale?width=640&amp;aspectRatio=1.78&amp;format=png" />
-              <img alt="" class="item__image hover-image"
+              <img class="item__image hover-image" alt="Category hover image"
                 src="https://prod-ripcut-delivery.disney-plus.net/v1/rawFiles/disney/RAW_C061B00E543326DA345FBF996B4D3D76422B58A49FDEE9AD9A2664618619A8F9" />
             </div>
           </a>
@@ -188,9 +187,9 @@
         <div class="item">
           <a href="public/pages/catepages/pixar/pixarpage.html">
             <div class=item__border>
-              <img class="item__image"
+              <img class="item__image" alt="Category image"
                 src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/7F4E1A299763030A0A8527227AD2812C049CE3E02822F7EDEFCFA1CFB703DDA5/scale?width=640&aspectRatio=1.78&format=png" />
-              <img alt="" class="item__image hover-image"
+              <img class="item__image hover-image" alt="Category hover image"
                 src="https://prod-ripcut-delivery.disney-plus.net/v1/rawFiles/disney/RAW_92FA84DF0F5D951171B41E5947716ADA382A15AE5DA37869E9D592D043F49316" />
             </div>
           </a>
@@ -198,9 +197,9 @@
         <div class="item">
           <a href="public/pages/catepages/marvel/marvelpage.html">
             <div class=item__border>
-              <img class="item__image"
+              <img class="item__image" alt="Category image"
                 src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/C90088DCAB7EA558159C0A79E4839D46B5302B5521BAB1F76D2E807D9E2C6D9A/scale?width=640&aspectRatio=1.78&format=png" />
-              <img alt="" class="item__image hover-image"
+              <img class="item__image hover-image" alt="Category hover image"
                 src="https://prod-ripcut-delivery.disney-plus.net/v1/rawFiles/disney/RAW_B8F3C4DDB037CD1840A53BDFA0AA0504E9FDDE7781D62D28230D5C74F2B06624" />
             </div>
           </a>
@@ -208,17 +207,17 @@
         <div class="item">
           <a href="public/pages/catepages/dc/dcpage.html">
             <div class=item__border>
-              <img class="item__image" src="public/img/imgcardeffect.png" />
-              <img alt="" class="item__image hover-image" src="https://media.giphy.com/media/kVzs4xE9nTkYg/giphy.gif" />
+              <img class="item__image" alt="Category image" src="public/img/imgcardeffect.png" />
+              <img class="item__image hover-image" alt="Category hover image" src="https://media.giphy.com/media/kVzs4xE9nTkYg/giphy.gif" />
             </div>
           </a>
         </div>
 
         <!-- <div class="item">
           <div class=item__border>
-            <img class="item__image"
+            <img class="item__image" alt="Category image"
               src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/2EF24AA0A1E648E6D1A3B26491F516632137ED87AB22969D153316F8BD670FB5/scale?width=640&aspectRatio=1.78&format=png" />
-            <img alt="" class="item__image hover-image"
+            <img class="item__image hover-image" alt="Category hover image"
               src="https://prod-ripcut-delivery.disney-plus.net/v1/rawFiles/disney/RAW_16793CC7E2AF7B8687B0DD00673503CBC14CB2C801952D62B4551B6866073650" />
           </div>
         </div> -->
@@ -230,13 +229,13 @@
     <h1 class="title">MARVEL</h1>
     <div class="movies-list">
       <div class="inetr-hid">
-        <button class="pre-btn"><img src="public/img/pre.png" alt=""></button>
-        <button class="nxt-btn"><img src="public/img/nxt.png" alt=""></button>
+        <button class="pre-btn"><img src="public/img/pre.png" alt="Previous slide"></button>
+        <button class="nxt-btn"><img src="public/img/nxt.png" alt="Next slide"></button>
         <div class="card-container">
           <div class="card">
             <img
               src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/BC43084FDE2395898283560F553EA284E5D9A65A3062564F9286891E0FD84F41/scale?width=400&aspectRatio=1.78&format=jpeg"
-              class="card-img" alt="">
+              class="card-img" alt="Movie poster">
             <a href="public/pages/marvel/spidermanhomecoming.html">
               <div class="card-body">
 
@@ -246,7 +245,7 @@
           <div class="card">
             <img
               src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/A4B58B11C7019B5403E07D551249121C4F4CC99119907F4460F0725B34A27086/scale?width=400&aspectRatio=1.78&format=jpeg"
-              class="card-img" alt="">
+              class="card-img" alt="Movie poster">
             <a href="public/pages/marvel/avengersendgame.html">
               <div class="card-body">
 
@@ -256,7 +255,7 @@
           <div class="card">
             <img
               src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/096710DCDBF4015BD51E95E05FF49CD680B16C8EB494368A97EA468AE7975CA7/scale?width=400&aspectRatio=1.78&format=jpeg"
-              class="card-img" alt="">
+              class="card-img" alt="Movie poster">
             <a href="public/pages/marvel/theamazingspiderman2.html">
               <div class="card-body">
 
@@ -266,7 +265,7 @@
           <div class="card ">
             <img
             src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/52C108DF6292E38F697B97A15684BB24A4A7B02D70D1B6B72B7D65E75D24B7A0/scale?width=400&aspectRatio=1.78&format=jpeg"
-            class="card-img" alt="">
+            class="card-img" alt="Movie poster">
             <a href="public/pages/marvel/captainamericacivilwar.html">
               <div class="card-body">
 
@@ -276,7 +275,7 @@
           <div class="card">
             <img
             src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/09088E90F08CFF49A8D1DF828AFECAA08CE7D42BB5D6CFE7718209A474EA2229/scale?width=400&aspectRatio=1.78&format=jpeg"
-            class="card-img" alt="">
+            class="card-img" alt="Movie poster">
             <a href="public/pages/marvel/ThorLoveandThunder.html">
               <div class="card-body">
 
@@ -286,7 +285,7 @@
           <div class="card">
             <img
             srcset="https://thumb.canalplus.pro/http/unsafe/332x186/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793, https://thumb.canalplus.pro/http/unsafe/664x372/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793 2x"
-            class="card-img" alt="">
+            class="card-img" alt="Movie poster">
             <a href="public/pages/marvel/SpiderManNoWayHome.html">
               <div class="card-body">
 
@@ -296,7 +295,7 @@
           <div class="card">
             <img
             src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/B07FABAA52E9F1962D1A3EE997F99564D8F77C567258EA93C17485A646776504/scale?width=400&aspectRatio=1.78&format=jpeg"
-            class="card-img" alt="">
+            class="card-img" alt="Movie poster">
             <a href="public/pages/marvel/avengersinfinitywar.html">
               <div class="card-body">
 
@@ -306,7 +305,7 @@
           <div class="card">
             <img
             src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/ADA256E903D911CE4232B7071120432753E6C30A63E1E62DCAD9951785C3EF2F/scale?width=400&aspectRatio=1.78&format=jpeg"
-            class="card-img" alt="">
+            class="card-img" alt="Movie poster">
             <a href="public/pages/marvel/IronMan3.html">
               <div class="card-body">
 
@@ -316,7 +315,7 @@
           <div class="card">
             <img
             src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/06C83811F429D570FE23D53D3F3D31D3315DF0A830F3B0CCE02B15E8299DC8C5/scale?width=400&aspectRatio=1.78&format=jpeg"
-            class="card-img" alt="">
+            class="card-img" alt="Movie poster">
             <a href="public/pages/marvel/LesGardiensdelaGalaxie.html">
               <div class="card-body">
 
@@ -326,7 +325,7 @@
           <div class="card">
             <img
             src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/DDCFEF24AB9ED385C588EAFA23AF44AD5260DA1150A8EE210CD533506F9D640A/scale?width=400&aspectRatio=1.78&format=jpeg"
-            class="card-img" alt="">
+            class="card-img" alt="Movie poster">
             <a href="public/pages/marvel/DoctorStrangeintheMultiverseofMadness.html">
               <div class="card-body">
 
@@ -341,13 +340,13 @@
     <!-- ///////////////////////////////////////////////////////////////////////////////////////////// -->
     <h1 class="title">DISNEY</h1>
     <div class="movies-list">
-      <button class="pre-btn"><img src="public/img/pre.png" alt=""></button>
-      <button class="nxt-btn"><img src="public/img/nxt.png" alt=""></button>
+      <button class="pre-btn"><img src="public/img/pre.png" alt="Previous slide"></button>
+      <button class="nxt-btn"><img src="public/img/nxt.png" alt="Next slide"></button>
       <div class="card-container">
         <div class="card">
           <img
           src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/C79814CD0D4F46B8CD1161B4E8A89AD341F18F8D0A764A73466641F760E0299A/scale?width=400&aspectRatio=1.78&format=jpeg"
-          class="card-img" alt="">
+          class="card-img" alt="Movie poster">
           <a href="public/pages/disney/EncantolafantastiquefamilleMadrigal.html">
             <div class="card-body">
              
@@ -357,7 +356,7 @@
         <div class="card">
           <img
           src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/E20FD4CF10323F3D84B0D1E32F9BB2DDE5C7799C0B35CF50D0B43A07B98BEFBB/scale?width=400&aspectRatio=1.78&format=jpeg"
-          class="card-img" alt="">
+          class="card-img" alt="Movie poster">
           <a href="public/pages/disney/RayaetleDernierDragon.html">
           <div class="card-body">
               
@@ -367,7 +366,7 @@
         <div class="card">
           <img
           src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/9CA683E08AF7D2F4C0A50A0EF024F141E44CF8DF7CC411CECAEA5168E8F2D731/scale?width=400&aspectRatio=1.78&format=jpeg"
-          class="card-img" alt="">
+          class="card-img" alt="Movie poster">
           <a href="public/pages/disney/LeRoiLion.html">
             <div class="card-body">
              
@@ -377,7 +376,7 @@
         <div class="card">
           <img
           src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/40FD1445971A298DE083DDD1D285264CBE133226DD61A580F9B147011DBECC3C/badging?width=400&aspectRatio=1.78&format=jpeg&label=disneyplusoriginal"
-          class="card-img" alt="">
+          class="card-img" alt="Movie poster">
           <a href="public/pages/disney/L'agedeglaceLesAventuresdeBuckWild.html">
             <div class="card-body">
               
@@ -387,7 +386,7 @@
         <div class="card">
           <img
           src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/092BED832C4106D5FED6BD1C2FA5BF4B091D8B4D9B72EA062E78D4BE7DDAED57/scale?width=400&aspectRatio=1.78&format=jpeg"
-          class="card-img" alt="">
+          class="card-img" alt="Movie poster">
           <a href="public/pages/disney/BuzzlEclair.html">
             <div class="card-body">
              
@@ -397,7 +396,7 @@
         <div class="card">
           <img
           src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/BA107CAF5E0A0F876926B6696FB127BFEE9ED40A26923DFAF0303C1205C49934/scale?width=400&aspectRatio=1.78&format=jpeg"
-          class="card-img" alt="">
+          class="card-img" alt="Movie poster">
           <a href="public/pages/disney/LeLivredelajungle.html">
             <div class="card-body">
               
@@ -407,7 +406,7 @@
         <div class="card">
           <img
           src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/74837103CFC36C9E82C27589E8290F906B00A27A3AA5BB12906C009163C16978/scale?width=400&aspectRatio=1.78&format=jpeg"
-          class="card-img" alt="">
+          class="card-img" alt="Movie poster">
           <a href="public/pages/disney/Mulan.html">
             <div class="card-body">
               
@@ -417,7 +416,7 @@
         <div class="card">
           <img
           src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-          class="card-img" alt="">
+          class="card-img" alt="Movie poster">
           <a href="public/pages/disney/LaReinedesneiges2.html">
             <div class="card-body">
               
@@ -425,7 +424,7 @@
           </a>
         </div>
         <div class="card">
-          <img src="public/img/poster 8.png" class="card-img" alt="">
+          <img src="public/img/poster 8.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -433,7 +432,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 9.png" class="card-img" alt="">
+          <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -441,7 +440,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 10.png" class="card-img" alt="">
+          <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -449,7 +448,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 11.png" class="card-img" alt="">
+          <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -457,7 +456,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 11.png" class="card-img" alt="">
+          <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -465,7 +464,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 1.png" class="card-img" alt="">
+          <img src="public/img/poster 1.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -473,7 +472,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 5.png" class="card-img" alt="">
+          <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -481,7 +480,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 5.png" class="card-img" alt="">
+          <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -489,7 +488,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 9.png" class="card-img" alt="">
+          <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -497,7 +496,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 10.png" class="card-img" alt="">
+          <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -505,7 +504,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 6.png" class="card-img" alt="">
+          <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -513,7 +512,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 3.png" class="card-img" alt="">
+          <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -521,7 +520,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster13.jfif" class="card-img" alt="">
+          <img src="public/img/poster13.jfif" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -536,11 +535,11 @@
 
     <h1 class="title">DC</h1>
     <div class="movies-list">
-      <button class="pre-btn"><img src="public/img/pre.png" alt=""></button>
-      <button class="nxt-btn"><img src="public/img/nxt.png" alt=""></button>
+      <button class="pre-btn"><img src="public/img/pre.png" alt="Previous slide"></button>
+      <button class="nxt-btn"><img src="public/img/nxt.png" alt="Next slide"></button>
       <div class="card-container">
         <div class="card">
-          <img src="public/img/poster 1.png" class="card-img" alt="">
+          <img src="public/img/poster 1.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -548,7 +547,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 2.png" class="card-img" alt="">
+          <img src="public/img/poster 2.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -556,7 +555,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 3.png" class="card-img" alt="">
+          <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -564,7 +563,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 4.png" class="card-img" alt="">
+          <img src="public/img/poster 4.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -572,7 +571,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 5.png" class="card-img" alt="">
+          <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -580,7 +579,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 5.png" class="card-img" alt="">
+          <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -588,7 +587,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 6.png" class="card-img" alt="">
+          <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -596,7 +595,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 7.png" class="card-img" alt="">
+          <img src="public/img/poster 7.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -604,7 +603,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 8.png" class="card-img" alt="">
+          <img src="public/img/poster 8.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -612,7 +611,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 9.png" class="card-img" alt="">
+          <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -620,7 +619,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 10.png" class="card-img" alt="">
+          <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -628,7 +627,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 11.png" class="card-img" alt="">
+          <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -636,7 +635,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 11.png" class="card-img" alt="">
+          <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -644,7 +643,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 1.png" class="card-img" alt="">
+          <img src="public/img/poster 1.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -652,7 +651,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 5.png" class="card-img" alt="">
+          <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -660,7 +659,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 5.png" class="card-img" alt="">
+          <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -668,7 +667,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 9.png" class="card-img" alt="">
+          <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -676,7 +675,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 10.png" class="card-img" alt="">
+          <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -684,7 +683,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 6.png" class="card-img" alt="">
+          <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -692,7 +691,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster 3.png" class="card-img" alt="">
+          <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -700,7 +699,7 @@
           </div>
         </div>
         <div class="card">
-          <img src="public/img/poster13.jfif" class="card-img" alt="">
+          <img src="public/img/poster13.jfif" class="card-img" alt="Movie poster">
           <div class="card-body">
             <h2 class="name">movie name</h2>
             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>

--- a/public/pages/catepages/dc/dcpage.html
+++ b/public/pages/catepages/dc/dcpage.html
@@ -12,12 +12,12 @@
 </head>
 
 <body class="bodydc" >
-    <img class="imgbackpngdc border-0" src="../../../img/imgwhite.png" alt="">
+    <img class="imgbackpngdc border-0" src="../../../img/imgwhite.png" alt="Background image">
 
     <header class=" mb-1 ">
-        <nav class="navbar navbar-expand-lg navbarindex navbarpagesdc ">
+        <nav class="navbar navbar-expand-lg navbarindex navbarpagesdc " aria-label="Main navigation">
             <div class="bigdiv container-fluid">
-                <a class="navbar-brand" href="../../../../index.html"><img class="img-acceuil" src="../../../img/disquepluslogo3.png"></a>
+                <a class="navbar-brand" href="../../../../index.html"><img class="img-acceuil" src="../../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                     data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                     aria-expanded="false" aria-label="Toggle navigation">
@@ -26,19 +26,19 @@
                 <div class="collapse navbar-collapse " id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="../../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                            <a class="nav-link hover-3" aria-current="page" href="../../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                         </li>
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="../../../pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                            <a class="nav-link hover-3" aria-current="page" href="../../../pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                         </li>
                         <!-- <li class="nav-item ms-4 link-wrapper">
                             <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                         </li> -->
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                         </li>
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                         </li>
                     </ul>
 
@@ -53,12 +53,12 @@
         <!-- <video class="videomarvelpage" id="content_video" playsinline src="../../video/marvelpage.mp4"
             poster="../../img/scale.jfif" style="width:100%;  " type="video/mp4"></video> -->
             
-        <!-- <img class="videomarvelpage" src="../../img/marvelpage_AdobeExpress.gif" style="width:100%; background-attachment:scroll;" alt="">
-        <img class="imgremplace" src="../../img/scale.jfif" style="width:100%;" alt=""> -->
+        <!-- <img class="videomarvelpage" src="../../img/marvelpage_AdobeExpress.gif" style="width:100%; background-attachment:scroll;" alt="Decorative image">
+        <img class="imgremplace" src="../../img/scale.jfif" style="width:100%;" alt="Decorative image"> -->
         
     </div>
 
-    <main class="marvelpagemain">
+    <main class="marvelpagemain" role="main">
 
 
 
@@ -67,11 +67,11 @@
         <div class="bigdivmovielist ">
             <h1 class="title">MARVEL</h1>
             <div class="movies-list movies-list-marvelpage">
-                <button class="pre-btn"><img src="../../img/pre.png" alt=""></button>
-                <button class="nxt-btn"><img src="../../img/nxt.png" alt=""></button>
+                <button class="pre-btn"><img src="../../img/pre.png" alt="Previous slide"></button>
+                <button class="nxt-btn"><img src="../../img/nxt.png" alt="Next slide"></button>
                 <div class="card-container card-container-marvelpage">
                     <div class="card">
-                        <img src="../..//img/scale (3).jfif" class="card-img" alt="">
+                        <img src="../..//img/scale (3).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/spidermanhomecoming.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -81,7 +81,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (2).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (2).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersendgame.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -91,7 +91,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -99,7 +99,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 4.png" class="card-img" alt="">
+                        <img src="public/img/poster 4.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -107,7 +107,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -115,7 +115,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -123,7 +123,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -131,7 +131,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 7.png" class="card-img" alt="">
+                        <img src="public/img/poster 7.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -139,7 +139,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 8.png" class="card-img" alt="">
+                        <img src="public/img/poster 8.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -147,7 +147,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -155,7 +155,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -163,7 +163,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -171,7 +171,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -179,7 +179,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (1).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (1).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersinfinitywar.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -189,7 +189,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -197,7 +197,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -205,7 +205,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -213,7 +213,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -221,7 +221,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -229,7 +229,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -237,7 +237,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster13.jfif" class="card-img" alt="">
+                        <img src="public/img/poster13.jfif" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -249,11 +249,11 @@
             </div>
             <h1 class="title">MARVEL</h1>
             <div class="movies-list movies-list-marvelpage">
-                <button class="pre-btn"><img src="public/img/pre.png" alt=""></button>
-                <button class="nxt-btn"><img src="public/img/nxt.png" alt=""></button>
+                <button class="pre-btn"><img src="public/img/pre.png" alt="Previous slide"></button>
+                <button class="nxt-btn"><img src="public/img/nxt.png" alt="Next slide"></button>
                 <div class="card-container card-container-marvelpage">
                     <div class="card">
-                        <img src="public/img/scale (3).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (3).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/spidermanhomecoming.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -263,7 +263,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (2).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (2).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersendgame.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -273,7 +273,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -281,7 +281,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 4.png" class="card-img" alt="">
+                        <img src="public/img/poster 4.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -289,7 +289,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -297,7 +297,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -305,7 +305,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -313,7 +313,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 7.png" class="card-img" alt="">
+                        <img src="public/img/poster 7.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -321,7 +321,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 8.png" class="card-img" alt="">
+                        <img src="public/img/poster 8.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -329,7 +329,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -337,7 +337,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -345,7 +345,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -353,7 +353,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -361,7 +361,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (1).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (1).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersinfinitywar.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -371,7 +371,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -379,7 +379,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -387,7 +387,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -395,7 +395,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -403,7 +403,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -411,7 +411,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -419,7 +419,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster13.jfif" class="card-img" alt="">
+                        <img src="public/img/poster13.jfif" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>

--- a/public/pages/catepages/disney/disneypage.html
+++ b/public/pages/catepages/disney/disneypage.html
@@ -12,12 +12,12 @@
 </head>
 
 <body class="bodydisney">
-    <img class="imgbackpngdisney border border-0 " src="../../../img/imgwhite.png" alt="">
+    <img class="imgbackpngdisney border border-0 " src="../../../img/imgwhite.png" alt="Background image">
     
     <header class=" mb-1 ">
-        <nav class="navbar navbar-expand-lg navbarindex navbarpagesdisney ">
+        <nav class="navbar navbar-expand-lg navbarindex navbarpagesdisney " aria-label="Main navigation">
             <div class="bigdiv container-fluid">
-                <a class="navbar-brand" href="../../../../index.html"><img class="img-acceuil" src="../../../img/disquepluslogo3.png"></a>
+                <a class="navbar-brand" href="../../../../index.html"><img class="img-acceuil" src="../../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                     data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                     aria-expanded="false" aria-label="Toggle navigation">
@@ -26,19 +26,19 @@
                 <div class="collapse navbar-collapse " id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="../../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                            <a class="nav-link hover-3" aria-current="page" href="../../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                         </li>
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="../../../pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                            <a class="nav-link hover-3" aria-current="page" href="../../../pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                         </li>
                         <!-- <li class="nav-item ms-4 link-wrapper">
                             <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                         </li> -->
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                         </li>
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                         </li>
                     </ul>
 
@@ -53,12 +53,12 @@
         <!-- <video class="videomarvelpage" id="content_video" playsinline src="../../video/marvelpage.mp4"
             poster="../../img/scale.jfif" style="width:100%;  " type="video/mp4"></video> -->
             
-        <!-- <img class="videomarvelpage" src="../../img/marvelpage_AdobeExpress.gif" style="width:100%; background-attachment:scroll;" alt="">
-        <img class="imgremplace" src="../../img/scale.jfif" style="width:100%;" alt=""> -->
+        <!-- <img class="videomarvelpage" src="../../img/marvelpage_AdobeExpress.gif" style="width:100%; background-attachment:scroll;" alt="Decorative image">
+        <img class="imgremplace" src="../../img/scale.jfif" style="width:100%;" alt="Decorative image"> -->
         
     </div>
 
-    <main class="disneypagemain border border-0">
+    <main class="disneypagemain border border-0" role="main">
 
 
 
@@ -67,11 +67,11 @@
         <div class="bigdivmovielist ">
             <h1 class="title">MARVEL</h1>
             <div class="movies-list movies-list-marvelpage">
-                <button class="pre-btn"><img src="../../img/pre.png" alt=""></button>
-                <button class="nxt-btn"><img src="../../img/nxt.png" alt=""></button>
+                <button class="pre-btn"><img src="../../img/pre.png" alt="Previous slide"></button>
+                <button class="nxt-btn"><img src="../../img/nxt.png" alt="Next slide"></button>
                 <div class="card-container card-container-marvelpage">
                     <div class="card">
-                        <img src="../..//img/scale (3).jfif" class="card-img border-0" alt="">
+                        <img src="../..//img/scale (3).jfif" class="card-img border-0" alt="Movie poster">
                         <a href="public/pages/marvel/spidermanhomecoming.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -81,7 +81,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (2).jfif" class="card-img " alt="">
+                        <img src="public/img/scale (2).jfif" class="card-img " alt="Movie poster">
                         <a href="public/pages/marvel/avengersendgame.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -91,7 +91,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -99,7 +99,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 4.png" class="card-img" alt="">
+                        <img src="public/img/poster 4.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -107,7 +107,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -115,7 +115,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -123,7 +123,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -131,7 +131,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 7.png" class="card-img" alt="">
+                        <img src="public/img/poster 7.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -139,7 +139,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 8.png" class="card-img" alt="">
+                        <img src="public/img/poster 8.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -147,7 +147,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -155,7 +155,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -163,7 +163,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -171,7 +171,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -179,7 +179,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (1).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (1).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersinfinitywar.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -189,7 +189,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -197,7 +197,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -205,7 +205,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -213,7 +213,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -221,7 +221,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -229,7 +229,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -237,7 +237,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster13.jfif" class="card-img" alt="">
+                        <img src="public/img/poster13.jfif" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -249,11 +249,11 @@
             </div>
             <h1 class="title">MARVEL</h1>
             <div class="movies-list movies-list-marvelpage">
-                <button class="pre-btn"><img src="public/img/pre.png" alt=""></button>
-                <button class="nxt-btn"><img src="public/img/nxt.png" alt=""></button>
+                <button class="pre-btn"><img src="public/img/pre.png" alt="Previous slide"></button>
+                <button class="nxt-btn"><img src="public/img/nxt.png" alt="Next slide"></button>
                 <div class="card-container card-container-marvelpage">
                     <div class="card">
-                        <img src="public/img/scale (3).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (3).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/spidermanhomecoming.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -263,7 +263,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (2).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (2).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersendgame.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -273,7 +273,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -281,7 +281,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 4.png" class="card-img" alt="">
+                        <img src="public/img/poster 4.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -289,7 +289,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -297,7 +297,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -305,7 +305,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -313,7 +313,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 7.png" class="card-img" alt="">
+                        <img src="public/img/poster 7.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -321,7 +321,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 8.png" class="card-img" alt="">
+                        <img src="public/img/poster 8.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -329,7 +329,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -337,7 +337,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -345,7 +345,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -353,7 +353,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -361,7 +361,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (1).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (1).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersinfinitywar.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -371,7 +371,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -379,7 +379,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -387,7 +387,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -395,7 +395,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -403,7 +403,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -411,7 +411,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -419,7 +419,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster13.jfif" class="card-img" alt="">
+                        <img src="public/img/poster13.jfif" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>

--- a/public/pages/catepages/marvel/marvelpage.html
+++ b/public/pages/catepages/marvel/marvelpage.html
@@ -12,12 +12,11 @@
 </head>
 
 <body class="bodymarvel">
-    <img class="imgbackpng border-0" src="../../../img/imgwhite.png" alt="">
+    <img class="imgbackpng border-0" src="../../../img/imgwhite.png" alt="Background image">
     <header class=" mb-1 ">
-        <nav class="navbar navbar-expand-lg navbarindex navbarpages ">
+        <nav class="navbar navbar-expand-lg navbarindex navbarpages " aria-label="Main navigation">
             <div class="bigdiv container-fluid">
-                <a class="navbar-brand" href="../../../../index.html"><img class="img-acceuil"
-                    src="../../../img/disquepluslogo3.png"></a>
+                <a class="navbar-brand" href="../../../../index.html"><img class="img-acceuil" src="../../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
                     <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                     data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                     aria-expanded="false" aria-label="Toggle navigation">
@@ -26,11 +25,9 @@
                 <div class="collapse navbar-collapse " id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="../../../../index.html"><span><svg
-                                        aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform=""
+                            <a class="nav-link hover-3" aria-current="page" href="../../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform=""
                                         version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"
-                                        data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link">
-                                        <title></title>
+                                        data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title>
                                         <path
                                         d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z"
                                         class="sc-hzDkRC kzwgVO"></path>
@@ -40,11 +37,9 @@
                             </li>
                         <li class="nav-item ms-4 link-wrapper">
                             <a class="nav-link hover-3" aria-current="page"
-                            href="../../../pages/search/search.html"><span><svg aria-hidden="true"
-                                aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1"
+                            href="../../../pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1"
                                 viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE"
-                                class="sc-jhAzac vfaMf svg-nav-link">
-                                <title></title>
+                                class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title>
                                 <path
                                 d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z"
                                 class="sc-hzDkRC kzwgVO"></path>
@@ -56,11 +51,9 @@
                                 <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                             </li> -->
                             <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-hidden=" true"
-                                aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1"
+                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1"
                                 viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS"
-                                class="sc-jhAzac vfaMf svg-nav-link">
-                                <title></title>
+                                class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title>
                                 <path
                                 d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838"
                                     class="sc-hzDkRC kzwgVO"></path></svg></span>
@@ -68,11 +61,9 @@
                                 </a>
                         </li>
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-hidden=" true"
-                                aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1"
+                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1"
                                 viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES"
-                                class="sc-jhAzac vfaMf svg-nav-link">
-                                <title></title>
+                                class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title>
                                 <path
                                 d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z"
                                 class="sc-hzDkRC kzwgVO"></path></svg></span>
@@ -93,12 +84,12 @@
         <!-- <video class="videomarvelpage" id="content_video" playsinline src="../../video/marvelpage.mp4"
             poster="../../img/scale.jfif" style="width:100%;  " type="video/mp4"></video> -->
 
-        <!-- <img class="videomarvelpage" src="../../img/marvelpage_AdobeExpress.gif" style="width:100%; background-attachment:scroll;" alt="">
-        <img class="imgremplace" src="../../img/scale.jfif" style="width:100%;" alt=""> -->
+        <!-- <img class="videomarvelpage" src="../../img/marvelpage_AdobeExpress.gif" style="width:100%; background-attachment:scroll;" alt="Decorative image">
+        <img class="imgremplace" src="../../img/scale.jfif" style="width:100%;" alt="Decorative image"> -->
 
     </div>
 
-    <main class="marvelpagemain">
+    <main class="marvelpagemain" role="main">
 
 
 
@@ -107,13 +98,13 @@
         <div class="bigdivmovielist ">
             <h1 class="title">Univers cinématographique Marvel phase I</h1>
             <div class="movies-list movies-list-marvelpage">
-                <button class="pre-btn"><img src="../../../img/pre.png" alt=""></button>
-                <button class="nxt-btn"><img src="../../..//img/nxt.png" alt=""></button>
+                <button class="pre-btn"><img src="../../../img/pre.png" alt="Previous slide"></button>
+                <button class="nxt-btn"><img src="../../..//img/nxt.png" alt="Next slide"></button>
                 <div class="card-container">
                     <div class="card">
                         <a href="../../../pages/marvel/ironman1.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/EAEA7A6A30CF7AF96370D97FEACA1ABBFBBF4D837AB24391566BE5C67F71DF8E/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -122,7 +113,7 @@
                     <div class="card">
                         <a href="../../../pages/marvel/CaptainAmericaFirstAvenger.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/5E17CE7825EAEB4BDD7E5A1C25FF1A56B52EF2E138144BEAA82BE6B8864E9B83/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -130,7 +121,7 @@
                     </div>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/096710DCDBF4015BD51E95E05FF49CD680B16C8EB494368A97EA468AE7975CA7/scale?width=400&aspectRatio=1.78&format=jpeg"
-                            class="card-img" alt="">
+                            class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/theamazingspiderman2.html">
                             <div class="card-body">
 
@@ -140,7 +131,7 @@
                     <div class="card ">
                         <a href="public/pages/marvel/captainamericacivilwar.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/52C108DF6292E38F697B97A15684BB24A4A7B02D70D1B6B72B7D65E75D24B7A0/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -149,7 +140,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/ThorLoveandThunder.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/09088E90F08CFF49A8D1DF828AFECAA08CE7D42BB5D6CFE7718209A474EA2229/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -158,7 +149,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/SpiderManNoWayHome.html">
                             <img srcset="https://thumb.canalplus.pro/http/unsafe/332x186/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793, https://thumb.canalplus.pro/http/unsafe/664x372/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793 2x"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -167,7 +158,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/avengersinfinitywar.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/B07FABAA52E9F1962D1A3EE997F99564D8F77C567258EA93C17485A646776504/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -176,7 +167,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/IronMan3.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/ADA256E903D911CE4232B7071120432753E6C30A63E1E62DCAD9951785C3EF2F/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -185,7 +176,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/LesGardiensdelaGalaxie.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/06C83811F429D570FE23D53D3F3D31D3315DF0A830F3B0CCE02B15E8299DC8C5/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -194,7 +185,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/DoctorStrangeintheMultiverseofMadness.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/DDCFEF24AB9ED385C588EAFA23AF44AD5260DA1150A8EE210CD533506F9D640A/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -206,13 +197,13 @@
             </div>
             <h1 class="title">Univers cinématographique Marvel phase II</h1>
             <div class="movies-list movies-list-marvelpage">
-                <button class="pre-btn"><img src="../../../img/pre.png" alt=""></button>
-                <button class="nxt-btn"><img src="../../..//img/nxt.png" alt=""></button>
+                <button class="pre-btn"><img src="../../../img/pre.png" alt="Previous slide"></button>
+                <button class="nxt-btn"><img src="../../..//img/nxt.png" alt="Next slide"></button>
                 <div class="card-container">
                     <div class="card">
                         <a href="../../../pages/marvel/ironman1.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/EAEA7A6A30CF7AF96370D97FEACA1ABBFBBF4D837AB24391566BE5C67F71DF8E/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -220,7 +211,7 @@
                     </div>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/A4B58B11C7019B5403E07D551249121C4F4CC99119907F4460F0725B34A27086/scale?width=400&aspectRatio=1.78&format=jpeg"
-                            class="card-img" alt="">
+                            class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersendgame.html">
                             <div class="card-body">
 
@@ -229,7 +220,7 @@
                     </div>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/096710DCDBF4015BD51E95E05FF49CD680B16C8EB494368A97EA468AE7975CA7/scale?width=400&aspectRatio=1.78&format=jpeg"
-                            class="card-img" alt="">
+                            class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/theamazingspiderman2.html">
                             <div class="card-body">
 
@@ -239,7 +230,7 @@
                     <div class="card ">
                         <a href="public/pages/marvel/captainamericacivilwar.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/52C108DF6292E38F697B97A15684BB24A4A7B02D70D1B6B72B7D65E75D24B7A0/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -248,7 +239,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/ThorLoveandThunder.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/09088E90F08CFF49A8D1DF828AFECAA08CE7D42BB5D6CFE7718209A474EA2229/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -257,7 +248,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/SpiderManNoWayHome.html">
                             <img srcset="https://thumb.canalplus.pro/http/unsafe/332x186/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793, https://thumb.canalplus.pro/http/unsafe/664x372/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793 2x"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -266,7 +257,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/avengersinfinitywar.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/B07FABAA52E9F1962D1A3EE997F99564D8F77C567258EA93C17485A646776504/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -275,7 +266,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/IronMan3.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/ADA256E903D911CE4232B7071120432753E6C30A63E1E62DCAD9951785C3EF2F/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -284,7 +275,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/LesGardiensdelaGalaxie.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/06C83811F429D570FE23D53D3F3D31D3315DF0A830F3B0CCE02B15E8299DC8C5/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -293,7 +284,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/DoctorStrangeintheMultiverseofMadness.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/DDCFEF24AB9ED385C588EAFA23AF44AD5260DA1150A8EE210CD533506F9D640A/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -305,13 +296,13 @@
             </div>
             <h1 class="title">Univers cinématographique Marvel phase III</h1>
             <div class="movies-list movies-list-marvelpage">
-                <button class="pre-btn"><img src="../../../img/pre.png" alt=""></button>
-                <button class="nxt-btn"><img src="../../..//img/nxt.png" alt=""></button>
+                <button class="pre-btn"><img src="../../../img/pre.png" alt="Previous slide"></button>
+                <button class="nxt-btn"><img src="../../..//img/nxt.png" alt="Next slide"></button>
                 <div class="card-container">
                     <div class="card">
                         <a href="../../../pages/marvel/ironman1.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/EAEA7A6A30CF7AF96370D97FEACA1ABBFBBF4D837AB24391566BE5C67F71DF8E/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -319,7 +310,7 @@
                     </div>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/A4B58B11C7019B5403E07D551249121C4F4CC99119907F4460F0725B34A27086/scale?width=400&aspectRatio=1.78&format=jpeg"
-                            class="card-img" alt="">
+                            class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersendgame.html">
                             <div class="card-body">
 
@@ -328,7 +319,7 @@
                     </div>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/096710DCDBF4015BD51E95E05FF49CD680B16C8EB494368A97EA468AE7975CA7/scale?width=400&aspectRatio=1.78&format=jpeg"
-                            class="card-img" alt="">
+                            class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/theamazingspiderman2.html">
                             <div class="card-body">
 
@@ -338,7 +329,7 @@
                     <div class="card ">
                         <a href="public/pages/marvel/captainamericacivilwar.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/52C108DF6292E38F697B97A15684BB24A4A7B02D70D1B6B72B7D65E75D24B7A0/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -347,7 +338,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/ThorLoveandThunder.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/09088E90F08CFF49A8D1DF828AFECAA08CE7D42BB5D6CFE7718209A474EA2229/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -356,7 +347,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/SpiderManNoWayHome.html">
                             <img srcset="https://thumb.canalplus.pro/http/unsafe/332x186/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793, https://thumb.canalplus.pro/http/unsafe/664x372/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793 2x"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -365,7 +356,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/avengersinfinitywar.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/B07FABAA52E9F1962D1A3EE997F99564D8F77C567258EA93C17485A646776504/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -374,7 +365,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/IronMan3.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/ADA256E903D911CE4232B7071120432753E6C30A63E1E62DCAD9951785C3EF2F/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -383,7 +374,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/LesGardiensdelaGalaxie.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/06C83811F429D570FE23D53D3F3D31D3315DF0A830F3B0CCE02B15E8299DC8C5/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -392,7 +383,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/DoctorStrangeintheMultiverseofMadness.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/DDCFEF24AB9ED385C588EAFA23AF44AD5260DA1150A8EE210CD533506F9D640A/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -404,13 +395,13 @@
             </div>
             <h1 class="title">Univers cinématographique Marvel phase IV</h1>
             <div class="movies-list movies-list-marvelpage">
-                <button class="pre-btn"><img src="../../../img/pre.png" alt=""></button>
-                <button class="nxt-btn"><img src="../../..//img/nxt.png" alt=""></button>
+                <button class="pre-btn"><img src="../../../img/pre.png" alt="Previous slide"></button>
+                <button class="nxt-btn"><img src="../../..//img/nxt.png" alt="Next slide"></button>
                 <div class="card-container">
                     <div class="card">
                         <a href="../../../pages/marvel/ironman1.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/EAEA7A6A30CF7AF96370D97FEACA1ABBFBBF4D837AB24391566BE5C67F71DF8E/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -418,7 +409,7 @@
                     </div>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/A4B58B11C7019B5403E07D551249121C4F4CC99119907F4460F0725B34A27086/scale?width=400&aspectRatio=1.78&format=jpeg"
-                            class="card-img" alt="">
+                            class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersendgame.html">
                             <div class="card-body">
 
@@ -427,7 +418,7 @@
                     </div>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/096710DCDBF4015BD51E95E05FF49CD680B16C8EB494368A97EA468AE7975CA7/scale?width=400&aspectRatio=1.78&format=jpeg"
-                            class="card-img" alt="">
+                            class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/theamazingspiderman2.html">
                             <div class="card-body">
 
@@ -437,7 +428,7 @@
                     <div class="card ">
                         <a href="public/pages/marvel/captainamericacivilwar.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/52C108DF6292E38F697B97A15684BB24A4A7B02D70D1B6B72B7D65E75D24B7A0/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -446,7 +437,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/ThorLoveandThunder.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/09088E90F08CFF49A8D1DF828AFECAA08CE7D42BB5D6CFE7718209A474EA2229/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -455,7 +446,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/SpiderManNoWayHome.html">
                             <img srcset="https://thumb.canalplus.pro/http/unsafe/332x186/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793, https://thumb.canalplus.pro/http/unsafe/664x372/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793 2x"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -464,7 +455,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/avengersinfinitywar.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/B07FABAA52E9F1962D1A3EE997F99564D8F77C567258EA93C17485A646776504/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -473,7 +464,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/IronMan3.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/ADA256E903D911CE4232B7071120432753E6C30A63E1E62DCAD9951785C3EF2F/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -482,7 +473,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/LesGardiensdelaGalaxie.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/06C83811F429D570FE23D53D3F3D31D3315DF0A830F3B0CCE02B15E8299DC8C5/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>
@@ -491,7 +482,7 @@
                     <div class="card">
                         <a href="public/pages/marvel/DoctorStrangeintheMultiverseofMadness.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/DDCFEF24AB9ED385C588EAFA23AF44AD5260DA1150A8EE210CD533506F9D640A/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
 
                             </div>

--- a/public/pages/catepages/pixar/pixarpage.html
+++ b/public/pages/catepages/pixar/pixarpage.html
@@ -12,12 +12,12 @@
 </head>
 
 <body class="bodypixar">
-    <img class="imgbackpngpixar border border-0 " src="../../../img/imgwhite.png" alt="">
+    <img class="imgbackpngpixar border border-0 " src="../../../img/imgwhite.png" alt="Background image">
     
     <header class="  mb-1 ">
-        <nav class="navbar navbar-expand-lg navbarindex navbarpagespixar ">
+        <nav class="navbar navbar-expand-lg navbarindex navbarpagespixar " aria-label="Main navigation">
             <div class="bigdiv container-fluid">
-                <a class="navbar-brand" href="../../../../index.html"><img class="img-acceuil" src="../../../img/disquepluslogo3.png"></a>
+                <a class="navbar-brand" href="../../../../index.html"><img class="img-acceuil" src="../../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                     data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                     aria-expanded="false" aria-label="Toggle navigation">
@@ -26,19 +26,19 @@
                 <div class="collapse navbar-collapse " id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="../../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                            <a class="nav-link hover-3" aria-current="page" href="../../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                         </li>
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="../../../pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                            <a class="nav-link hover-3" aria-current="page" href="../../../pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                         </li>
                         <!-- <li class="nav-item ms-4 link-wrapper">
                             <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                         </li> -->
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                         </li>
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                            <a class="nav-link hover-3" aria-current="page" href="#""><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                         </li>
                     </ul>
 
@@ -53,12 +53,12 @@
         <!-- <video class="videomarvelpage" id="content_video" playsinline src="../../video/marvelpage.mp4"
             poster="../../img/scale.jfif" style="width:100%;  " type="video/mp4"></video> -->
             
-        <!-- <img class="videomarvelpage" src="../../img/marvelpage_AdobeExpress.gif" style="width:100%; background-attachment:scroll;" alt="">
-        <img class="imgremplace" src="../../img/scale.jfif" style="width:100%;" alt=""> -->
+        <!-- <img class="videomarvelpage" src="../../img/marvelpage_AdobeExpress.gif" style="width:100%; background-attachment:scroll;" alt="Decorative image">
+        <img class="imgremplace" src="../../img/scale.jfif" style="width:100%;" alt="Decorative image"> -->
         
     </div>
 
-    <main class="disneypagemain border border-0">
+    <main class="disneypagemain border border-0" role="main">
 
 
 
@@ -67,11 +67,11 @@
         <div class="bigdivmovielist ">
             <h1 class="title">MARVEL</h1>
             <div class="movies-list movies-list-marvelpage">
-                <button class="pre-btn"><img src="../../img/pre.png" alt=""></button>
-                <button class="nxt-btn"><img src="../../img/nxt.png" alt=""></button>
+                <button class="pre-btn"><img src="../../img/pre.png" alt="Previous slide"></button>
+                <button class="nxt-btn"><img src="../../img/nxt.png" alt="Next slide"></button>
                 <div class="card-container card-container-marvelpage">
                     <div class="card">
-                        <img src="../..//img/scale (3).jfif" class="card-img border-0" alt="">
+                        <img src="../..//img/scale (3).jfif" class="card-img border-0" alt="Movie poster">
                         <a href="public/pages/marvel/spidermanhomecoming.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -81,7 +81,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (2).jfif" class="card-img " alt="">
+                        <img src="public/img/scale (2).jfif" class="card-img " alt="Movie poster">
                         <a href="public/pages/marvel/avengersendgame.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -91,7 +91,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -99,7 +99,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 4.png" class="card-img" alt="">
+                        <img src="public/img/poster 4.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -107,7 +107,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -115,7 +115,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -123,7 +123,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -131,7 +131,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 7.png" class="card-img" alt="">
+                        <img src="public/img/poster 7.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -139,7 +139,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 8.png" class="card-img" alt="">
+                        <img src="public/img/poster 8.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -147,7 +147,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -155,7 +155,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -163,7 +163,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -171,7 +171,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -179,7 +179,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (1).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (1).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersinfinitywar.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -189,7 +189,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -197,7 +197,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -205,7 +205,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -213,7 +213,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -221,7 +221,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -229,7 +229,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -237,7 +237,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster13.jfif" class="card-img" alt="">
+                        <img src="public/img/poster13.jfif" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -249,11 +249,11 @@
             </div>
             <h1 class="title">MARVEL</h1>
             <div class="movies-list movies-list-marvelpage">
-                <button class="pre-btn"><img src="public/img/pre.png" alt=""></button>
-                <button class="nxt-btn"><img src="public/img/nxt.png" alt=""></button>
+                <button class="pre-btn"><img src="public/img/pre.png" alt="Previous slide"></button>
+                <button class="nxt-btn"><img src="public/img/nxt.png" alt="Next slide"></button>
                 <div class="card-container card-container-marvelpage">
                     <div class="card">
-                        <img src="public/img/scale (3).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (3).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/spidermanhomecoming.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -263,7 +263,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (2).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (2).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersendgame.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -273,7 +273,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -281,7 +281,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 4.png" class="card-img" alt="">
+                        <img src="public/img/poster 4.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -289,7 +289,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -297,7 +297,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -305,7 +305,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -313,7 +313,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 7.png" class="card-img" alt="">
+                        <img src="public/img/poster 7.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -321,7 +321,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 8.png" class="card-img" alt="">
+                        <img src="public/img/poster 8.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -329,7 +329,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -337,7 +337,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -345,7 +345,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -353,7 +353,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -361,7 +361,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/scale (1).jfif" class="card-img" alt="">
+                        <img src="public/img/scale (1).jfif" class="card-img" alt="Movie poster">
                         <a href="public/pages/marvel/avengersinfinitywar.html">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
@@ -371,7 +371,7 @@
                         </a>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -379,7 +379,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -387,7 +387,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -395,7 +395,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -403,7 +403,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -411,7 +411,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -419,7 +419,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster13.jfif" class="card-img" alt="">
+                        <img src="public/img/poster13.jfif" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>

--- a/public/pages/disney/BuzzlEclair.html
+++ b/public/pages/disney/BuzzlEclair.html
@@ -13,9 +13,9 @@
 
 <body>
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -24,19 +24,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -46,7 +46,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card  cardmovievideo mb-5">
   
@@ -57,7 +57,7 @@
                 
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/1A36582AA2F05098BA4C062E4CE9B1EE1ED3E78E699F852A953E6013EAA53177/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/1A36582AA2F05098BA4C062E4CE9B1EE1ED3E78E699F852A953E6013EAA53177/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
 
                 <p class="paramoviepage">La véritable histoire du légendaire Ranger de l’espace qui, depuis, a inspiré le jouet que nous connaissons tous. Après s’être échoué avec sa commandante et son équipage sur une planète hostile située à 4,2 millions d’années-lumière de la Terre, Buzz l’Eclair tente de ramener tout ce petit monde sain et sauf à la maison. Pour cela, il peut compter sur le soutien d’un groupe de jeunes recrues ambitieuses et sur son adorable chat robot, Sox. Mais l’arrivée du terrible Zurg et de son armée de robots impitoyables ne va pas leur faciliter la tâche, d’autant que ce dernier a un plan bien précis en tête…
                 </p>

--- a/public/pages/disney/EncantolafantastiquefamilleMadrigal.html
+++ b/public/pages/disney/EncantolafantastiquefamilleMadrigal.html
@@ -13,9 +13,9 @@
 
 <body>
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -24,19 +24,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -46,7 +46,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card  cardmovievideo mb-5">
   
@@ -57,7 +57,7 @@
                 
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/9B0214F8E4E261DA4E9F8CE1FD2AF0FC6749B427263D0C503712DE5B52183DDE/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/9B0214F8E4E261DA4E9F8CE1FD2AF0FC6749B427263D0C503712DE5B52183DDE/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
 
                 <p class="paramoviepage">Créé par Walt Disney Animation Studios avec une bande-son originale de Lin-Manuel Mirando, "Encanto, la fantastique famille Madrigal" raconte l'histoire d'une famille extraordinaire qui vit dans une maison magique en Colombie. Lorsque Mirabel, la seule à ne posséder aucun pouvoir, découvre que la magie de la maison est en danger, elle pourrait bien se révéler le dernier espoir de sa famille.</p>
             </div>

--- a/public/pages/disney/L'agedeglaceLesAventuresdeBuckWild.html
+++ b/public/pages/disney/L'agedeglaceLesAventuresdeBuckWild.html
@@ -13,9 +13,9 @@
 
 <body>
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -24,19 +24,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -46,7 +46,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card  cardmovievideo mb-5">
   
@@ -57,7 +57,7 @@
                 
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/EC7C9D715464C8C66E73441D9BB8DC7704962A4436E3A067D91E25F29B34F168/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/EC7C9D715464C8C66E73441D9BB8DC7704962A4436E3A067D91E25F29B34F168/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
 
                 <p class="paramoviepage">Avides d’indépendance et toujours en quête de sensations fortes, les frères opossums Crash et Eddie décident de chercher un habitat rien qu’à eux mais vont rapidement se retrouver piégés sous la glace, dans une immense grotte souterraine habitée par des dinosaures. Secourus par leur copain Buck Wild, une belette borgne excentrique, ils vont ensemble et avec l’aide de nouveaux amis se lancer dans une mission pour sauver le monde perdu de la domination des dinosaures.
                 </p>

--- a/public/pages/disney/LaReinedesneiges2.html
+++ b/public/pages/disney/LaReinedesneiges2.html
@@ -14,9 +14,9 @@
 <body>
 
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -25,19 +25,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -47,7 +47,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo">
   
@@ -58,7 +58,7 @@
               
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/59A9BEF6C2A4997CFAE0F821631E4041E9E52185CD9C98CEBC458E5D363AD589/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/59A9BEF6C2A4997CFAE0F821631E4041E9E52185CD9C98CEBC458E5D363AD589/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
                
                 <p class="paramoviepage">  Pourquoi Elsa est-elle née avec des pouvoirs magiques ? La jeune fille rêve de l’apprendre, mais la réponse met son royaume en danger. Avec l’aide d’Anna, Kristoff, Olaf et Sven, Elsa entreprend un voyage aussi périlleux qu’extraordinaire. Dans La Reine des neiges, Elsa craignait que ses pouvoirs ne menacent le monde. Dans La Reine des neiges 2, elle espère qu’ils seront assez puissants pour le sauver…
                 </p>

--- a/public/pages/disney/LeLivredelajungle.html
+++ b/public/pages/disney/LeLivredelajungle.html
@@ -14,9 +14,9 @@
 <body>
 
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -25,19 +25,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -47,7 +47,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo">
   
@@ -58,7 +58,7 @@
               
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/1D545DE25D62D3019653AFDC1F23F359675ABA406EB67C2CE16894B9C3F2488C/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/1D545DE25D62D3019653AFDC1F23F359675ABA406EB67C2CE16894B9C3F2488C/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
                
                 <p class="paramoviepage">  Les aventures de Mowgli, un petit homme élevé dans la jungle par une famille de loups. Mais Mowgli n'est plus le bienvenu dans la jungle depuis que le redoutable tigre Shere Khan, qui porte les cicatrices des hommes, promet d'éliminer celui qu'il considère comme une menace. Poussé à abandonner le seul foyer qu'il ait jamais connu, Mowgli se lance dans un voyage captivant, à la découverte de soi, guidé par son mentor la panthère Bagheera et l'ours Baloo. Sur le chemin, Mowgli rencontre des créatures comme Kaa, un pyton à la voix séduisante et au regard hypnotique et le Roi Louie, qui tente de contraindre Mowgli à lui révéler le secret de la fleur rouge et insaisissable : le feu.
                 </p>

--- a/public/pages/disney/LeRoiLion.html
+++ b/public/pages/disney/LeRoiLion.html
@@ -13,9 +13,9 @@
 
 <body>
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -24,19 +24,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -46,7 +46,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card  cardmovievideo mb-5">
   
@@ -57,7 +57,7 @@
                 
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/570E3D20F13ED9456A81D6057E046789D4D1FF5EDAEC3192049680EB6C5539CC/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/570E3D20F13ED9456A81D6057E046789D4D1FF5EDAEC3192049680EB6C5539CC/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
 
                 <p class="paramoviepage">Au fond de la savane africaine, tous les animaux célèbrent la naissance de Simba, leur futur roi. Les mois passent. Simba idolâtre son père, le roi Mufasa, qui prend à c?ur de lui faire comprendre les enjeux de sa royale destinée. Mais tout le monde ne semble pas de cet avis. Scar, le frère de Mufasa, l'ancien héritier du trône, a ses propres plans. La bataille pour la prise de contrôle de la Terre des Lions est ravagée par la trahison, la tragédie et le drame, ce qui finit par entraîner l'exil de Simba. Avec l'aide de deux nouveaux amis, Timon et Pumbaa, le jeune lion va devoir trouver comment grandir et reprendre ce qui lui revient de droit?
                 </p>

--- a/public/pages/disney/Mulan.html
+++ b/public/pages/disney/Mulan.html
@@ -14,9 +14,9 @@
 <body>
 
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -25,19 +25,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -47,7 +47,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo">
   
@@ -58,7 +58,7 @@
               
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/6F8E62B415250E641AB60BCA056EBF92EAAE551A10AF524857A3D33276E405C7/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/6F8E62B415250E641AB60BCA056EBF92EAAE551A10AF524857A3D33276E405C7/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
                
                 <p class="paramoviepage"> Lorsque l’Empereur de Chine publie un décret stipulant qu’un homme de chaque famille du pays doit intégrer l’armée impériale pour combattre des envahisseurs venus du nord, Hua Mulan, fille ainée d’un vénérable guerrier désormais atteint par la maladie, décide de prendre sa place au combat. Se faisant passer pour un soldat du nom de Hua Jun, elle se voit mise à l’épreuve à chaque étape du processus d’apprentissage, mobilisant chaque jour un peu plus sa force intérieure pour explorer son véritable potentiel… Commence alors pour Mulan un voyage épique qui transformera la jeune fille en une guerrière aux faits d’armes héroïques, honorée par tout un peuple reconnaissant et faisant la fierté de son père.
                 </p>

--- a/public/pages/disney/RayaetleDernierDragon.html
+++ b/public/pages/disney/RayaetleDernierDragon.html
@@ -13,9 +13,9 @@
 
 <body>
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -24,19 +24,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -46,7 +46,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card  cardmovievideo mb-5">
   
@@ -58,7 +58,7 @@
 
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/289778CD88DF2ACBEF230DA53116BDFCF75FE766715C0B7FD6D0602044528456/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/289778CD88DF2ACBEF230DA53116BDFCF75FE766715C0B7FD6D0602044528456/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
 
                 <p class="paramoviepage">Il y a de cela fort longtemps, au royaume imaginaire de Kumandra, humains et dragons vivaient en harmonie. Mais un jour, une force maléfique s’abattit sur le royaume et les dragons se sacrifièrent pour sauver l’humanité. Lorsque cette force réapparait cinq siècles plus tard, Raya, une guerrière solitaire, se met en quête du légendaire dernier dragon pour restaurer l’harmonie sur la terre de Kumandra, au sein d’un peuple désormais divisé. Commence pour elle un long voyage au cours duquel elle découvrira qu’il lui faudra bien plus qu’un dragon pour sauver le monde, et que la confiance et l’entraide seront essentiels pour conduire au succès cette périlleuse mission.
                 </p>

--- a/public/pages/marvel/CaptainAmericaFirstAvenger.html
+++ b/public/pages/marvel/CaptainAmericaFirstAvenger.html
@@ -13,9 +13,9 @@
 
 <body>
     <header class="headercolor mb-1">
-      <nav class="navbar navbar-expand-lg navbarindex  ">
+      <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
         <div class="bigdiv container-fluid">
-            <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+            <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                 data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                 aria-expanded="false" aria-label="Toggle navigation">
@@ -24,19 +24,19 @@
             <div class="collapse navbar-collapse " id="navbarSupportedContent">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                     <li class="nav-item ms-4 link-wrapper">
-                        <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                        <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                     </li>
                     <li class="nav-item ms-4 link-wrapper">
-                        <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                        <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                     </li>
                     <!-- <li class="nav-item ms-4 link-wrapper">
                         <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                     </li> -->
                     <li class="nav-item ms-4 link-wrapper">
-                        <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                        <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                     </li>
                     <li class="nav-item ms-4 link-wrapper">
-                        <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                        <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                     </li>
                 </ul>
   
@@ -46,7 +46,7 @@
     
     
       </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo mb-5" >
   
@@ -58,7 +58,7 @@
                 
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/E219EEBF06D3EFF109C9849816534CE3049452EF7D6D0A240C48E8D9EEF42146/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/E219EEBF06D3EFF109C9849816534CE3049452EF7D6D0A240C48E8D9EEF42146/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
                
                 <p class="paramoviepage"> Captain America: First Avenger nous plonge dans les premières années de l’univers Marvel. Steve Rogers, frêle et timide, se porte volontaire pour participer à un programme expérimental qui va le transformer en un Super Soldat connu sous le nom de Captain America. Allié à Bucky Barnes et Peggy Carter, il sera confronté à la diabolique organisation HYDRA dirigée par le redoutable Red Skull.</p>
             </div>

--- a/public/pages/marvel/DoctorStrangeintheMultiverseofMadness.html
+++ b/public/pages/marvel/DoctorStrangeintheMultiverseofMadness.html
@@ -14,9 +14,9 @@
 <body>
 
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -25,19 +25,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -47,7 +47,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo">
   
@@ -58,7 +58,7 @@
               
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/026A16CECA249D7F377E33172FA3F8AF55AB80321FBA54823F765E652321FE41/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/026A16CECA249D7F377E33172FA3F8AF55AB80321FBA54823F765E652321FE41/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
                
                 <p class="paramoviepage">Docteur Strange, avec l'aide d'alliés mystiques à la fois anciens et nouveaux, traverse les réalités alternatives dominées par l'esprit et dangereuses du Multiverse pour faire face à un nouvel adversaire mystérieux.
                 </p>

--- a/public/pages/marvel/IronMan3.html
+++ b/public/pages/marvel/IronMan3.html
@@ -14,9 +14,9 @@
 <body>
 
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -25,19 +25,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -47,7 +47,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo">
   
@@ -58,7 +58,7 @@
               
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/BB94349BC2A3105E49201A6FBE0823EC5C2E4D9FDBEB577B849BCE43A2C75EFB/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/BB94349BC2A3105E49201A6FBE0823EC5C2E4D9FDBEB577B849BCE43A2C75EFB/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
                
                 <p class="paramoviepage"> Tony Stark, l’industriel flamboyant qui est aussi Iron Man, est confronté cette fois à un ennemi qui va attaquer sur tous les fronts. Lorsque son univers personnel est détruit, Stark se lance dans une quête acharnée pour retrouver les coupables. Plus que jamais, son courage va être mis à l’épreuve, à chaque instant. Dos au mur, il ne peut plus compter que sur ses inventions, son ingéniosité, et son instinct pour protéger ses proches. Alors qu’il se jette dans la bataille, Stark va enfin découvrir la réponse à la question qui le hante secrètement depuis si longtemps : est-ce l’homme qui fait le costume ou bien le costume qui fait l’homme ?
                 </p>

--- a/public/pages/marvel/LesGardiensdelaGalaxie.html
+++ b/public/pages/marvel/LesGardiensdelaGalaxie.html
@@ -14,9 +14,9 @@
 <body>
 
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -25,19 +25,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -47,7 +47,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo">
   
@@ -58,7 +58,7 @@
               
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/18DF94CB871C7DF853D438DCC54C5DEFD8D72C3B58D4BAA40C96A16CB011FC4B/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/18DF94CB871C7DF853D438DCC54C5DEFD8D72C3B58D4BAA40C96A16CB011FC4B/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
                
                 <p class="paramoviepage">  Peter Quill est un aventurier traqué par tous les chasseurs de primes pour avoir volé un mystérieux globe convoité par le puissant Ronan, dont les agissements menacent l’univers tout entier. Lorsqu’il découvre le véritable pouvoir de ce globe et la menace qui pèse sur la galaxie, il conclut une alliance fragile avec quatre aliens disparates : Rocket, un raton laveur fin tireur, Groot, un humanoïde semblable à un arbre, l’énigmatique et mortelle Gamora, et Drax le Destructeur, qui ne rêve que de vengeance. En les ralliant à sa cause, il les convainc de livrer un ultime combat aussi désespéré soit-il pour sauver ce qui peut encore l’être …
                 </p>

--- a/public/pages/marvel/SpiderManNoWayHome.html
+++ b/public/pages/marvel/SpiderManNoWayHome.html
@@ -13,9 +13,9 @@
 
 <body>
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -24,19 +24,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -46,7 +46,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo mb-5" >
   
@@ -59,7 +59,7 @@
            
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="../../img/marvel3.png" alt="">
+                <img class="imgmovie" src="../../img/marvel3.png" alt="Movie image">
               
                 <p class="paramoviepage">Après les événements liés à l'affrontement avec Mysterio, l'identité secrète de Spider-Man a été révélée. Il est poursuivi par le gouvernement américain, qui l'accuse du meurtre de Mysterio, et traqué par les médias. Cet événement a également des conséquences terribles sur la vie de sa petite-amie M.J. et de son meilleur ami Ned. Désemparé, Peter Parker demande alors de l'aide au docteur Strange. Ce dernier lance un sort pour que tout le monde oublie que Peter est Spider-Man. Mais les choses ne se passent pas comme prévu, et cette action altère la stabilité de l'espace-temps. Cela ouvre le « multivers », un concept terrifiant dont ils ne savent quasiment rien...</p>
             </div>

--- a/public/pages/marvel/ThorLoveandThunder.html
+++ b/public/pages/marvel/ThorLoveandThunder.html
@@ -14,9 +14,9 @@
 <body>
 
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -25,19 +25,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -47,7 +47,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo mb-5" >
   
@@ -58,7 +58,7 @@
               
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/7F7D5C0D9B1E81ACC0487501DB16604290A594DD1F98CDC8392A95FA696E4FEA/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/7F7D5C0D9B1E81ACC0487501DB16604290A594DD1F98CDC8392A95FA696E4FEA/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
               
                 <p class="paramoviepage">Dans “Thor: Love and Thunder” des Marvel Studios, le dieu du tonnerre fait équipe avec le Roi Valkyrie, Korg et son ex-petite amie sous l'identité de Mighty Thor, Jane Foster, pour affronter un assassin galactique connu sous le nom de Gorr le Boucher des Dieux.</p>
             </div>

--- a/public/pages/marvel/avengersendgame.html
+++ b/public/pages/marvel/avengersendgame.html
@@ -13,9 +13,9 @@
 
 <body>
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -24,19 +24,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -46,7 +46,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card  cardmovievideo mb-5">
   
@@ -57,7 +57,7 @@
                 
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/37A85A377B82EE1778A35CB8074D01A594282B06A2357AFAD7E06CEDCB001F3B/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/37A85A377B82EE1778A35CB8074D01A594282B06A2357AFAD7E06CEDCB001F3B/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
 
                 <p class="paramoviepage">Final épique du phénomène mondial et salué par la critique qu'est devenue l'Infinity Saga, cet affrontement oppose les Avengers à Thanos. Après les événements dévastateurs qui ont anéanti la moitié de la population mondiale et divisé leurs rangs, les héros restants peinent à aller de l'avant. Mais ils n'ont d'autre choix que d'unir leurs forces pour restaurer l'ordre et l'harmonie dans l'univers, et sauver leurs proches.</p>
             </div>

--- a/public/pages/marvel/avengersinfinitywar.html
+++ b/public/pages/marvel/avengersinfinitywar.html
@@ -14,9 +14,9 @@
 <body>
 
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -25,19 +25,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -47,7 +47,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo">
   
@@ -58,7 +58,7 @@
               
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/1832D5CDF72E88186376612AB6176395CD8E0C6D9A3937F00D5C238C2AFB10ED/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/1832D5CDF72E88186376612AB6176395CD8E0C6D9A3937F00D5C238C2AFB10ED/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
                
                 <p class="paramoviepage"> Les Avengers et leurs alliés devront être prêts à tout sacrifier pour neutraliser le redoutable Thanos avant que son attaque éclair ne conduise à la destruction complète de l'univers.</p>
             </div>

--- a/public/pages/marvel/captainamericacivilwar.html
+++ b/public/pages/marvel/captainamericacivilwar.html
@@ -13,9 +13,9 @@
 
 <body>
     <header class="headercolor mb-1">
-      <nav class="navbar navbar-expand-lg navbarindex  ">
+      <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
         <div class="bigdiv container-fluid">
-            <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+            <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                 data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                 aria-expanded="false" aria-label="Toggle navigation">
@@ -24,19 +24,19 @@
             <div class="collapse navbar-collapse " id="navbarSupportedContent">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                     <li class="nav-item ms-4 link-wrapper">
-                        <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                        <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                     </li>
                     <li class="nav-item ms-4 link-wrapper">
-                        <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                        <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                     </li>
                     <!-- <li class="nav-item ms-4 link-wrapper">
                         <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                     </li> -->
                     <li class="nav-item ms-4 link-wrapper">
-                        <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                        <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                     </li>
                     <li class="nav-item ms-4 link-wrapper">
-                        <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                        <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                     </li>
                 </ul>
   
@@ -46,7 +46,7 @@
     
     
       </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo mb-5" >
   
@@ -58,7 +58,7 @@
                 
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/C2EC0C30A0D2B7E13D4840697FFAFA7B82BF5D3C2465EDAB8F8A2CBEB808CAF0/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/C2EC0C30A0D2B7E13D4840697FFAFA7B82BF5D3C2465EDAB8F8A2CBEB808CAF0/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
                
                 <p class="paramoviepage">Les Avengers sont tenus responsables d'importants dégâts collatéraux après la bataille contre Ultron. Le désaccord entre Captain America et Iron Man entraîne la bataille ultime de tous les héros.</p>
             </div>

--- a/public/pages/marvel/ironman1.html
+++ b/public/pages/marvel/ironman1.html
@@ -14,9 +14,9 @@
 <body>
 
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -25,19 +25,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -47,7 +47,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo">
   
@@ -58,7 +58,7 @@
               
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/86CC39EE95E05E4D705B95BE8A60AE6AF35CB3338D6B87F749055748D8B17242/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/86CC39EE95E05E4D705B95BE8A60AE6AF35CB3338D6B87F749055748D8B17242/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
                
                 <p class="paramoviepage">Tony Stark, inventeur de génie, vendeur d'armes et playboy milliardaire, est kidnappé en Aghanistan. Forcé par ses ravisseurs de fabriquer une arme redoutable, il construit en secret une armure high-tech révolutionnaire qu'il utilise pour s'échapper. Comprenant la puissance de cette armure, il décide de l'améliorer et de l'utiliser pour faire régner la justice et protéger les innocents.
                 </p>

--- a/public/pages/marvel/spidermanhomecoming.html
+++ b/public/pages/marvel/spidermanhomecoming.html
@@ -13,9 +13,9 @@
 
 <body>
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -24,19 +24,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -46,7 +46,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo mb-5" >
   
@@ -57,7 +57,7 @@
                 
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/5158ECCC6CE704FBA32058A91D6DA3AEDE8C8851C9C20FC5D94BE40250C0E43D/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/5158ECCC6CE704FBA32058A91D6DA3AEDE8C8851C9C20FC5D94BE40250C0E43D/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
 
                 <p class="paramoviepage">Alors que le puissant Thanos est en passe de réduire en cendres la moitié de l'univers, les Avengers et leurs alliés doivent se préparer aux plus grands sacrifices dans l'épreuve de force ultime.</p>
             </div>

--- a/public/pages/marvel/theamazingspiderman2.html
+++ b/public/pages/marvel/theamazingspiderman2.html
@@ -14,9 +14,9 @@
 <body>
 
   <header class="headercolor mb-1">
-    <nav class="navbar navbar-expand-lg navbarindex  ">
+    <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
       <div class="bigdiv container-fluid">
-          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png"></a>
+          <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
               data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
               aria-expanded="false" aria-label="Toggle navigation">
@@ -25,19 +25,19 @@
           <div class="collapse navbar-collapse " id="navbarSupportedContent">
               <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title><path d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>ACCUEIL</p></a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-hidden="true" aria-label="search" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="../../../public/pages/search/search.html"><span><svg aria-label="Search" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE" class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title><path d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>RECHERCHE</p></a>
                   </li>
                   <!-- <li class="nav-item ms-4 link-wrapper">
                       <a class="nav-link hover-3"  aria-current="page" href="../../pages/search/search.html">MA LISTE</a>
                   </li> -->
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS" class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title><path d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838" class="sc-hzDkRC kzwgVO"></path></svg></span><p>FILMS</p> </a>
                   </li>
                   <li class="nav-item ms-4 link-wrapper">
-                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-hidden="true" aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title></title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
+                      <a class="nav-link hover-3" aria-current="page" href="#"><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES" class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title><path d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z" class="sc-hzDkRC kzwgVO"></path></svg></span><p>SERIES</p></a>
                   </li>
               </ul>
 
@@ -47,7 +47,7 @@
 
 
   </header>
-    <main>
+    <main role="main">
         <section class=" section1-moviepage container mt-5">
             <div class="card cardmovievideo mb-5">
   
@@ -59,7 +59,7 @@
 
             </div>
             <div class="divresummovie">
-                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/40C6A04E3AD054A188F6CD75F414BE5BD603CDB965440F93E496FC6868ACF023/scale?width=1440&aspectRatio=1.78&format=png" alt="">
+                <img class="imgmovie" src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/40C6A04E3AD054A188F6CD75F414BE5BD603CDB965440F93E496FC6868ACF023/scale?width=1440&aspectRatio=1.78&format=png" alt="Movie image">
                
                 <p class="paramoviepage">Être Spider-Man est tout simplement génial, mais être un superhéros a un coût : seul Spider-Man est capable de protéger ses concitoyens new-yorkais des méchants redoutables qui menacent la ville. Avec l'émergence d'Electro, Peter doit affronter un adversaire bien plus puissant que lui. Et lorsque son vieil ami, Harry Osborn, revient, Peter se rend compte que ses ennemis ont tous un point en commun : la société Oscorp.</p>
             </div>

--- a/public/pages/search/search.html
+++ b/public/pages/search/search.html
@@ -13,10 +13,9 @@
 
 <body class="page-search">
     <header class="headercolor mb-1">
-        <nav class="navbar navbar-expand-lg navbarindex  ">
+        <nav class="navbar navbar-expand-lg navbarindex  " aria-label="Main navigation">
             <div class="bigdiv container-fluid">
-                <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil"
-                        src="../../img/disquepluslogo3.png"></a>
+                <a class="navbar-brand" href="../../../index.html"><img class="img-acceuil" src="../../img/disquepluslogo3.png" alt="DisquePlus logo"></a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                     data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                     aria-expanded="false" aria-label="Toggle navigation">
@@ -25,11 +24,9 @@
                 <div class="collapse navbar-collapse " id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0 link-cont">
                         <li class="nav-item ms-4 link-wrapper">
-                            <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg
-                                        aria-hidden="true" aria-label="home" color="#f9f9f9" role="img" transform=""
+                            <a class="nav-link hover-3" aria-current="page" href="../../../index.html"><span><svg aria-label="Home" role="img" color="#f9f9f9" transform=""
                                         version="1.1" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg"
-                                        data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link">
-                                        <title></title>
+                                        data-route="ACCUEIL" class="sc-jhAzac vfaMf svg-nav-link"><title>Home</title>
                                         <path
                                             d="M26.882 19.414v10.454h-5.974v-5.227h-5.974v5.227H8.961V19.414H5.227L17.921 6.72l12.694 12.694h-3.733z"
                                             class="sc-hzDkRC kzwgVO"></path>
@@ -39,11 +36,10 @@
                         </li>
                         <li class="nav-item ms-4 link-wrapper">
                             <a class="nav-link hover-3" aria-current="page"
-                                href="../../pages/search/search.html"><span><svg aria-hidden="true" aria-label="search"
-                                        color="#f9f9f9" role="img" transform="" version="1.1" viewBox="0 0 36 36"
+                                href="../../pages/search/search.html"><span><svg aria-label="Search" role="img"
+                                        color="#f9f9f9" transform="" version="1.1" viewBox="0 0 36 36"
                                         xmlns="http://www.w3.org/2000/svg" data-route="RECHERCHE"
-                                        class="sc-jhAzac vfaMf svg-nav-link">
-                                        <title></title>
+                                        class="sc-jhAzac vfaMf svg-nav-link"><title>Search</title>
                                         <path
                                             d="M21.866 24.337c-3.933 2.762-9.398 2.386-12.914-1.13-3.936-3.936-3.936-10.318 0-14.255 3.937-3.936 10.32-3.936 14.256 0 3.327 3.327 3.842 8.402 1.545 12.27l4.56 4.558a2 2 0 0 1 0 2.829l-.174.173a2 2 0 0 1-2.828 0l-4.445-4.445zm-5.786-1.36a6.897 6.897 0 1 0 0-13.794 6.897 6.897 0 0 0 0 13.794z"
                                             class="sc-hzDkRC kzwgVO"></path>
@@ -56,11 +52,9 @@
                         </li> -->
                         <li class="nav-item ms-4 link-wrapper">
                             <a class="nav-link hover-3" aria-current="page"
-                                href="../../pages/search/search.html""><span><svg aria-hidden=" true"
-                                aria-label="movies" color="#f9f9f9" role="img" transform="" version="1.1"
+                                href="../../pages/search/search.html""><span><svg aria-label="Movies" role="img" color="#f9f9f9" transform="" version="1.1"
                                 viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="FILMS"
-                                class="sc-jhAzac vfaMf svg-nav-link">
-                                <title></title>
+                                class="sc-jhAzac vfaMf svg-nav-link"><title>Movies</title>
                                 <path
                                     d="M24.71 20.07a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m-12.262 0a2.97 2.97 0 1 0-4.2-4.2 2.97 2.97 0 0 0 4.2 4.2m6.173-10.31a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m0 12.262a2.969 2.969 0 1 0-4.199 4.198 2.969 2.969 0 0 0 4.199-4.198m-1.544-4.629a.846.846 0 1 0-1.197 1.196.846.846 0 0 0 1.197-1.196m18.06-.644c-3.33 6.913-8.165 9.928-11.635 11.24-2.57.971-4.762 1.178-5.949 1.208-.348.032-.698.053-1.052.053C10.287 29.25 5.25 24.213 5.25 18S10.287 6.75 16.5 6.75c6.214 0 11.25 5.037 11.25 11.25a11.19 11.19 0 0 1-2.493 7.054c2.832-1.612 5.844-4.382 8.138-9.143a.968.968 0 0 1 1.742.838"
                                     class="sc-hzDkRC kzwgVO"></path></svg></span>
@@ -69,11 +63,9 @@
                         </li>
                         <li class="nav-item ms-4 link-wrapper">
                             <a class="nav-link hover-3" aria-current="page"
-                                href="../../pages/search/search.html""><span><svg aria-hidden=" true"
-                                aria-label="series" color="#f9f9f9" role="img" transform="" version="1.1"
+                                href="../../pages/search/search.html""><span><svg aria-label="Series" role="img" color="#f9f9f9" transform="" version="1.1"
                                 viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" data-route="SÉRIES"
-                                class="sc-jhAzac vfaMf svg-nav-link">
-                                <title></title>
+                                class="sc-jhAzac vfaMf svg-nav-link"><title>Series</title>
                                 <path
                                     d="M18.84 11.965h6.722a4 4 0 0 1 4 4V26a4 4 0 0 1-4 4H10.375a4 4 0 0 1-4-4V15.965a4 4 0 0 1 4-4h6.211l-3.981-3.981a1.162 1.162 0 1 1 1.643-1.644l3.465 3.465 3.464-3.465a1.162 1.162 0 0 1 1.644 1.644l-3.982 3.981zm6.428 7.73a1.718 1.718 0 1 0 0-3.436 1.718 1.718 0 0 0 0 3.436zm0 6.011a1.718 1.718 0 1 0 0-3.435 1.718 1.718 0 0 0 0 3.435z"
                                     class="sc-hzDkRC kzwgVO"></path></svg></span>
@@ -89,7 +81,7 @@
 
 
     </header>
-    <main class="mainsection">
+    <main class="mainsection" role="main">
         <div class="div-search ">
             <input class="bg-search mb-5" id="searchbar" onkeyup="search_animal()" type="text" name="search"
                 placeholder="Titre ou genre..">
@@ -110,7 +102,7 @@
                         class="dnone">marvel</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/BC43084FDE2395898283560F553EA284E5D9A65A3062564F9286891E0FD84F41/scale?width=400&aspectRatio=1.78&format=jpeg"
-                            class="card-img" alt="">
+                            class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/spidermanhomecoming.html">
                             <div class="card-body">
 
@@ -122,7 +114,7 @@
                         class="dnone">marvel</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/A4B58B11C7019B5403E07D551249121C4F4CC99119907F4460F0725B34A27086/scale?width=400&aspectRatio=1.78&format=jpeg"
-                            class="card-img" alt="">
+                            class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/avengersendgame.html">
                             <div class="card-body">
 
@@ -137,7 +129,7 @@
                         spider man 2</span><span class="dnone">marvel</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/096710DCDBF4015BD51E95E05FF49CD680B16C8EB494368A97EA468AE7975CA7/scale?width=400&aspectRatio=1.78&format=jpeg"
-                            class="card-img" alt="">
+                            class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/theamazingspiderman2.html">
                             <div class="card-body">
 
@@ -150,7 +142,7 @@
                         war</span><span class="dnone">marvel</span>
                     <div class="card ">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/52C108DF6292E38F697B97A15684BB24A4A7B02D70D1B6B72B7D65E75D24B7A0/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/captainamericacivilwar.html">
                             <div class="card-body">
 
@@ -162,7 +154,7 @@
                 <li class="movies"><span class="dnone">Captain America</span><span class="dnone">Captain America: First Avenger</span><span class="dnone">Captain America First Avenger</span><span class="dnone">Captain America 1</span><span class="dnone">marvel</span>
                     <div class="card ">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/5E17CE7825EAEB4BDD7E5A1C25FF1A56B52EF2E138144BEAA82BE6B8864E9B83/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/CaptainAmericaFirstAvenger.html">
                             <div class="card-body">
 
@@ -174,7 +166,7 @@
                         class="dnone">Thor Love and Thunder</span><span class="dnone">marvel</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/09088E90F08CFF49A8D1DF828AFECAA08CE7D42BB5D6CFE7718209A474EA2229/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/ThorLoveandThunder.html">
                             <div class="card-body">
 
@@ -187,7 +179,7 @@
                         class="dnone">marvel</span>
                     <div class="card">
                         <img srcset="https://thumb.canalplus.pro/http/unsafe/332x186/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793, https://thumb.canalplus.pro/http/unsafe/664x372/filters:quality(80)/img-hapi.canalplus.pro:80/ServiceImage/ImageID/108137793 2x"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/SpiderManNoWayHome.html">
                             <div class="card-body">
 
@@ -199,7 +191,7 @@
                         war</span><span class="dnone">marvel</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/B07FABAA52E9F1962D1A3EE997F99564D8F77C567258EA93C17485A646776504/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/avengersinfinitywar.html">
                             <div class="card-body">
 
@@ -211,7 +203,7 @@
                         class="dnone">iron man3</span><span class="dnone">iron man 3</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/ADA256E903D911CE4232B7071120432753E6C30A63E1E62DCAD9951785C3EF2F/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/IronMan3.html">
                             <div class="card-body">
 
@@ -223,7 +215,7 @@
                         class="dnone">iron man1</span><span class="dnone">iron man 1</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/EAEA7A6A30CF7AF96370D97FEACA1ABBFBBF4D837AB24391566BE5C67F71DF8E/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/ironman1.html">
                             <div class="card-body">
 
@@ -235,7 +227,7 @@
                         de la Galaxie 1</span><span class="dnone">Les Gardiens de la Galaxie1</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/06C83811F429D570FE23D53D3F3D31D3315DF0A830F3B0CCE02B15E8299DC8C5/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/LesGardiensdelaGalaxie.html">
                             <div class="card-body">
 
@@ -248,7 +240,7 @@
                     </span><span class="dnone">Doctor Strange 2</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/DDCFEF24AB9ED385C588EAFA23AF44AD5260DA1150A8EE210CD533506F9D640A/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="../../pages/marvel/DoctorStrangeintheMultiverseofMadness.html">
                             <div class="card-body">
 
@@ -262,7 +254,7 @@
                         class="dnone">disney</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/C79814CD0D4F46B8CD1161B4E8A89AD341F18F8D0A764A73466641F760E0299A/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="public/pages/disney/EncantolafantastiquefamilleMadrigal.html">
                             <div class="card-body">
 
@@ -273,7 +265,7 @@
                 <li class="movies"><span class="dnone">Raya et le Dernier Dragon</span><span class="dnone">disney</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/E20FD4CF10323F3D84B0D1E32F9BB2DDE5C7799C0B35CF50D0B43A07B98BEFBB/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="public/pages/disney/RayaetleDernierDragon.html">
                             <div class="card-body">
 
@@ -284,7 +276,7 @@
                 <li class="movies"><span class="dnone">le roi lion</span><span class="dnone">disney</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/9CA683E08AF7D2F4C0A50A0EF024F141E44CF8DF7CC411CECAEA5168E8F2D731/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="public/pages/disney/LeRoiLion.html">
                             <div class="card-body">
 
@@ -298,7 +290,7 @@
                         class="dnone">L'age de glace Les Aventures de Buck Wild</span><span class="dnone">disney</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/40FD1445971A298DE083DDD1D285264CBE133226DD61A580F9B147011DBECC3C/badging?width=400&aspectRatio=1.78&format=jpeg&label=disneyplusoriginal"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="public/pages/disney/L'agedeglaceLesAventuresdeBuckWild.html">
                             <div class="card-body">
 
@@ -310,7 +302,7 @@
                         class="dnone">disney</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/092BED832C4106D5FED6BD1C2FA5BF4B091D8B4D9B72EA062E78D4BE7DDAED57/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="public/pages/disney/BuzzlEclair.html">
                             <div class="card-body">
 
@@ -321,7 +313,7 @@
                 <li class="movies"><span class="dnone">Le Livre de la jungle</span><span class="dnone">disney</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/BA107CAF5E0A0F876926B6696FB127BFEE9ED40A26923DFAF0303C1205C49934/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="public/pages/disney/LeLivredelajungle.html">
                             <div class="card-body">
 
@@ -332,7 +324,7 @@
                 <li class="movies"><span class="dnone">Mulan</span><span class="dnone">disney</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/74837103CFC36C9E82C27589E8290F906B00A27A3AA5BB12906C009163C16978/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="public/pages/disney/Mulan.html">
                             <div class="card-body">
 
@@ -344,7 +336,7 @@
                         neiges2</span><span class="dnone">La Reine des neiges</span><span class="dnone">disney</span>
                     <div class="card">
                         <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                        class="card-img" alt="">
+                        class="card-img" alt="Movie poster">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <div class="card-body">
                                 
@@ -358,7 +350,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -372,7 +364,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -386,7 +378,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -400,7 +392,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -414,7 +406,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -428,7 +420,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -442,7 +434,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -456,7 +448,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -470,7 +462,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -484,7 +476,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -498,7 +490,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -512,7 +504,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -526,7 +518,7 @@
                     <div class="card">
                         <a href="public/pages/disney/LaReinedesneiges2.html">
                             <img src="https://prod-ripcut-delivery.disney-plus.net/v1/variant/disney/36E23696C9BAB564302DAF7E6F9C38EBC450ABA9CF6DD92E512FD6CB8C97A1F2/scale?width=400&aspectRatio=1.78&format=jpeg"
-                                class="card-img" alt="">
+                                class="card-img" alt="Movie poster">
                             <div class="card-body">
                                 <h2 class="name">movie name</h2>
                                 <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -551,11 +543,11 @@
 
 
             <!-- <div class="movies-list">
-                <button class="pre-btn"><img src="public/img/pre.png" alt=""></button>
-                <button class="nxt-btn"><img src="public/img/nxt.png" alt=""></button>
+                <button class="pre-btn"><img src="public/img/pre.png" alt="Previous slide"></button>
+                <button class="nxt-btn"><img src="public/img/nxt.png" alt="Next slide"></button>
                 <div class="card-container">
                     <div class="card">
-                        <img src="public/img/poster 1.png" class="card-img" alt="">
+                        <img src="public/img/poster 1.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -563,7 +555,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 2.png" class="card-img" alt="">
+                        <img src="public/img/poster 2.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -571,7 +563,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -579,7 +571,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 4.png" class="card-img" alt="">
+                        <img src="public/img/poster 4.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -587,7 +579,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -595,7 +587,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -603,7 +595,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -611,7 +603,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 7.png" class="card-img" alt="">
+                        <img src="public/img/poster 7.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -619,7 +611,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 8.png" class="card-img" alt="">
+                        <img src="public/img/poster 8.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -627,7 +619,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -635,7 +627,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -643,7 +635,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -651,7 +643,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 11.png" class="card-img" alt="">
+                        <img src="public/img/poster 11.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -659,7 +651,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 1.png" class="card-img" alt="">
+                        <img src="public/img/poster 1.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -667,7 +659,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -675,7 +667,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 5.png" class="card-img" alt="">
+                        <img src="public/img/poster 5.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -683,7 +675,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 9.png" class="card-img" alt="">
+                        <img src="public/img/poster 9.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -691,7 +683,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 10.png" class="card-img" alt="">
+                        <img src="public/img/poster 10.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -699,7 +691,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 6.png" class="card-img" alt="">
+                        <img src="public/img/poster 6.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -707,7 +699,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster 3.png" class="card-img" alt="">
+                        <img src="public/img/poster 3.png" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>
@@ -715,7 +707,7 @@
                         </div>
                     </div>
                     <div class="card">
-                        <img src="public/img/poster13.jfif" class="card-img" alt="">
+                        <img src="public/img/poster13.jfif" class="card-img" alt="Movie poster">
                         <div class="card-body">
                             <h2 class="name">movie name</h2>
                             <h6 class="des">Lorem ipsum dolor sit amet consectetur.</h6>


### PR DESCRIPTION
## Summary
- add descriptive alt text to site images
- label SVG icons and navigation sections for screen readers
- introduce ARIA roles on navigation and main content

## Testing
- `npx lighthouse http://localhost:8080/index.html --only-categories=accessibility --quiet --chrome-flags="--headless" --output json --output-path=./lighthouse-report.json` *(fails: CHROME_PATH environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6897d56f57dc832bac291fdb47216c4d