### PR TITLE
refactor: centralize carousel logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -736,7 +736,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
     crossorigin="anonymous"></script>
-  <script src="./public/main.js"></script>
+  <script type="module" src="./public/main.js"></script>
 
 </body>
 

--- a/public/js/carousel.js
+++ b/public/js/carousel.js
@@ -1,0 +1,17 @@
+export function initCarousel(containerSelector, prevSelector, nextSelector) {
+  const containers = [...document.querySelectorAll(containerSelector)];
+  const prevButtons = [...document.querySelectorAll(prevSelector)];
+  const nextButtons = [...document.querySelectorAll(nextSelector)];
+
+  containers.forEach((container, index) => {
+    const containerWidth = container.getBoundingClientRect().width;
+
+    nextButtons[index].addEventListener('click', () => {
+      container.scrollLeft += containerWidth - 200;
+    });
+
+    prevButtons[index].addEventListener('click', () => {
+      container.scrollLeft -= containerWidth + 200;
+    });
+  });
+}

--- a/public/main.js
+++ b/public/main.js
@@ -1,4 +1,4 @@
-
+import { initCarousel } from './js/carousel.js';
 
 // const videoCards = [...document.querySelectorAll('.video-card')];
 
@@ -20,22 +20,7 @@
 // cards carousel
 
 
-let cardContainers = [...document.querySelectorAll('.card-container')];
-let preBtns = [...document.querySelectorAll('.pre-btn')];
-let nxtBtns = [...document.querySelectorAll('.nxt-btn')];
-
-cardContainers.forEach((item, i) => {
-    let containerDimensions = item.getBoundingClientRect();
-    let containerWidth = containerDimensions.width;
-
-    nxtBtns[i].addEventListener('click', () => {
-        item.scrollLeft += containerWidth - 200;
-    })
-
-    preBtns[i].addEventListener('click', () => {
-        item.scrollLeft -= containerWidth + 200;
-    })
-})
+initCarousel('.card-container', '.pre-btn', '.nxt-btn');
 // fin cards carousel
 // cards carousel search page
 

--- a/public/pages/catepages/dc/dcpage.html
+++ b/public/pages/catepages/dc/dcpage.html
@@ -457,7 +457,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
         crossorigin="anonymous"></script>
-    <script src="dcpage.js"></script>
+    <script type="module" src="dcpage.js"></script>
 
 </body>
 

--- a/public/pages/catepages/dc/dcpage.js
+++ b/public/pages/catepages/dc/dcpage.js
@@ -1,22 +1,7 @@
+import { initCarousel } from '../../../js/carousel.js';
+
 // cards carousel
-
-
-let cardContainers = [...document.querySelectorAll('.card-container')];
-let preBtns = [...document.querySelectorAll('.pre-btn')];
-let nxtBtns = [...document.querySelectorAll('.nxt-btn')];
-
-cardContainers.forEach((item, i) => {
-    let containerDimensions = item.getBoundingClientRect();
-    let containerWidth = containerDimensions.width;
-
-    nxtBtns[i].addEventListener('click', () => {
-        item.scrollLeft += containerWidth - 200;
-    })
-
-    preBtns[i].addEventListener('click', () => {
-        item.scrollLeft -= containerWidth + 200;
-    })
-})
+initCarousel('.card-container', '.pre-btn', '.nxt-btn');
 // fin cards carousel
 
 // page marvel

--- a/public/pages/catepages/disney/disneypage.html
+++ b/public/pages/catepages/disney/disneypage.html
@@ -457,7 +457,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
         crossorigin="anonymous"></script>
-    <script src="disneypage.js"></script>
+    <script type="module" src="disneypage.js"></script>
 
 </body>
 

--- a/public/pages/catepages/disney/disneypage.js
+++ b/public/pages/catepages/disney/disneypage.js
@@ -1,22 +1,7 @@
+import { initCarousel } from '../../../js/carousel.js';
+
 // cards carousel
-
-
-let cardContainers = [...document.querySelectorAll('.card-container')];
-let preBtns = [...document.querySelectorAll('.pre-btn')];
-let nxtBtns = [...document.querySelectorAll('.nxt-btn')];
-
-cardContainers.forEach((item, i) => {
-    let containerDimensions = item.getBoundingClientRect();
-    let containerWidth = containerDimensions.width;
-
-    nxtBtns[i].addEventListener('click', () => {
-        item.scrollLeft += containerWidth - 200;
-    })
-
-    preBtns[i].addEventListener('click', () => {
-        item.scrollLeft -= containerWidth + 200;
-    })
-})
+initCarousel('.card-container', '.pre-btn', '.nxt-btn');
 // fin cards carousel
 
 // disney page effect

--- a/public/pages/catepages/marvel/marvelpage.html
+++ b/public/pages/catepages/marvel/marvelpage.html
@@ -529,7 +529,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
         crossorigin="anonymous"></script>
-    <script src="marvelpage.js"></script>
+    <script type="module" src="marvelpage.js"></script>
 
 </body>
 

--- a/public/pages/catepages/marvel/marvelpage.js
+++ b/public/pages/catepages/marvel/marvelpage.js
@@ -1,22 +1,7 @@
+import { initCarousel } from '../../../js/carousel.js';
+
 // cards carousel
-
-
-let cardContainers = [...document.querySelectorAll('.card-container')];
-let preBtns = [...document.querySelectorAll('.pre-btn')];
-let nxtBtns = [...document.querySelectorAll('.nxt-btn')];
-
-cardContainers.forEach((item, i) => {
-    let containerDimensions = item.getBoundingClientRect();
-    let containerWidth = containerDimensions.width;
-
-    nxtBtns[i].addEventListener('click', () => {
-        item.scrollLeft += containerWidth - 200;
-    })
-
-    preBtns[i].addEventListener('click', () => {
-        item.scrollLeft -= containerWidth + 200;
-    })
-})
+initCarousel('.card-container', '.pre-btn', '.nxt-btn');
 // fin cards carousel
 
 // page marvel

--- a/public/pages/catepages/pixar/pixarpage.html
+++ b/public/pages/catepages/pixar/pixarpage.html
@@ -457,7 +457,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
         crossorigin="anonymous"></script>
-    <script src="pixarpage.js"></script>
+    <script type="module" src="pixarpage.js"></script>
 
 </body>
 

--- a/public/pages/catepages/pixar/pixarpage.js
+++ b/public/pages/catepages/pixar/pixarpage.js
@@ -1,22 +1,7 @@
+import { initCarousel } from '../../../js/carousel.js';
+
 // cards carousel
-
-
-let cardContainers = [...document.querySelectorAll('.card-container')];
-let preBtns = [...document.querySelectorAll('.pre-btn')];
-let nxtBtns = [...document.querySelectorAll('.nxt-btn')];
-
-cardContainers.forEach((item, i) => {
-    let containerDimensions = item.getBoundingClientRect();
-    let containerWidth = containerDimensions.width;
-
-    nxtBtns[i].addEventListener('click', () => {
-        item.scrollLeft += containerWidth - 200;
-    })
-
-    preBtns[i].addEventListener('click', () => {
-        item.scrollLeft -= containerWidth + 200;
-    })
-})
+initCarousel('.card-container', '.pre-btn', '.nxt-btn');
 // fin cards carousel
 
 // disney page effect


### PR DESCRIPTION
## Summary
- add reusable `initCarousel` helper
- use shared helper in main and category page scripts
- load scripts as ES modules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897d591322c832ba1558961ffe672ba