### PR TITLE
Refactor frontend scripts into ES modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -736,7 +736,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
     crossorigin="anonymous"></script>
-  <script src="./public/main.js"></script>
+  <script type="module" src="./public/main.js"></script>
 
 </body>
 

--- a/public/main.js
+++ b/public/main.js
@@ -17,25 +17,10 @@
 // })
 
 
+import { initCarousel } from './utils.js';
+
 // cards carousel
-
-
-let cardContainers = [...document.querySelectorAll('.card-container')];
-let preBtns = [...document.querySelectorAll('.pre-btn')];
-let nxtBtns = [...document.querySelectorAll('.nxt-btn')];
-
-cardContainers.forEach((item, i) => {
-    let containerDimensions = item.getBoundingClientRect();
-    let containerWidth = containerDimensions.width;
-
-    nxtBtns[i].addEventListener('click', () => {
-        item.scrollLeft += containerWidth - 200;
-    })
-
-    preBtns[i].addEventListener('click', () => {
-        item.scrollLeft -= containerWidth + 200;
-    })
-})
+initCarousel('.card-container', '.pre-btn', '.nxt-btn');
 // fin cards carousel
 // cards carousel search page
 
@@ -67,35 +52,27 @@ cardContainers.forEach((item, i) => {
 
 // barre de recherche 
 
-// JavaScript code 
-function search_animal() { 
-    let input = document.getElementById('searchbar').value 
-    input=input.toLowerCase(); 
-    let x = document.getElementsByClassName('movies'); 
-      
-    for (i = 0; i < x.length; i++) {  
-        
-        if (!x[i].innerHTML.toLowerCase().includes(input)) { 
-            x[i].style.display="none"; 
-        } 
-        else { 
-            x[i].style.display="list-item";                  
-        } 
-    } 
-} 
+// JavaScript code
+window.search_animal = () => {
+    const input = document.getElementById('searchbar').value.toLowerCase();
+    const movies = document.getElementsByClassName('movies');
+
+    Array.from(movies).forEach(movie => {
+        movie.style.display = movie.innerHTML.toLowerCase().includes(input)
+            ? 'list-item'
+            : 'none';
+    });
+};
 
 // logo movile
-let divmobil = document.querySelector('.div-mobil')
-window.addEventListener("scroll", function (){
-    let navScroll = window.scrollY
+const divmobil = document.querySelector('.div-mobil');
+window.addEventListener('scroll', () => {
+    const navScroll = window.scrollY;
     if (navScroll >= 20) {
-        divmobil.style.transition = "0.5s"
-        divmobil.classList.add('opacity')
+        divmobil.style.transition = '0.5s';
+        divmobil.classList.add('opacity');
+    } else {
+        divmobil.classList.remove('opacity');
     }
-    else{
-        divmobil.classList.remove('opacity')
-    }
-})
-// 
-
+});
 

--- a/public/pages/catepages/dc/dcpage.html
+++ b/public/pages/catepages/dc/dcpage.html
@@ -457,7 +457,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
         crossorigin="anonymous"></script>
-    <script src="dcpage.js"></script>
+    <script type="module" src="dcpage.js"></script>
 
 </body>
 

--- a/public/pages/catepages/dc/dcpage.js
+++ b/public/pages/catepages/dc/dcpage.js
@@ -1,26 +1,11 @@
+import { initCarousel } from '../../../utils.js';
+
 // cards carousel
-
-
-let cardContainers = [...document.querySelectorAll('.card-container')];
-let preBtns = [...document.querySelectorAll('.pre-btn')];
-let nxtBtns = [...document.querySelectorAll('.nxt-btn')];
-
-cardContainers.forEach((item, i) => {
-    let containerDimensions = item.getBoundingClientRect();
-    let containerWidth = containerDimensions.width;
-
-    nxtBtns[i].addEventListener('click', () => {
-        item.scrollLeft += containerWidth - 200;
-    })
-
-    preBtns[i].addEventListener('click', () => {
-        item.scrollLeft -= containerWidth + 200;
-    })
-})
+initCarousel('.card-container', '.pre-btn', '.nxt-btn');
 // fin cards carousel
 
 // page marvel
-var bodydc = document.querySelector('.bodydc')
+const bodydc = document.querySelector('.bodydc');
 
 document.querySelector('.bodydc').style.background = "url('../../../img/dcpage (13).gif') ";
 document.querySelector('.bodydc').style.backgroundSize  = "100%";
@@ -29,7 +14,7 @@ document.querySelector('.bodydc').style.backgroundColor   = " #131520";
 // bodymarvel.attributes.background.style.opacity    = " 0.5";
 bodydc.style.backgroundAttachment    = " fixed";
 
-setInterval(function () {
+setInterval(() => {
 
     document.querySelector('.bodydc').style.background = "url('../../../img/scale5.PNG') ";
     document.querySelector('.bodydc').style.backgroundRepeat  = "no-repeat";
@@ -37,7 +22,7 @@ setInterval(function () {
     document.querySelector('.bodydc').style.backgroundColor   = " #131520";
     bodydc.style.backgroundAttachment    = " fixed";
 
-    
+
 }, 7640);
 // fin page marvel
 
@@ -50,32 +35,32 @@ setInterval(function () {
 // navbarpages effect 
 
 
-let navbarpagesdc = document.querySelector('.navbarpagesdc')
-window.addEventListener("scroll", function (){
-    let navScroll = window.scrollY
+const navbarpagesdc = document.querySelector('.navbarpagesdc');
+window.addEventListener('scroll', () => {
+    const navScroll = window.scrollY;
 
     if (navScroll >= 100) {
-        navbarpagesdc.classList.add('navback')
-        navbarpagesdc.style.position = "fixed"
-        // navbarpagesdc.style.top = "0"
-        navbarpagesdc.style.width = "100%"
-        navbarpagesdc.style.zIndex  = "9"
-        navbarpagesdc.style.transition = "0.5s"
+        navbarpagesdc.classList.add('navback');
+        navbarpagesdc.style.position = 'fixed';
+        // navbarpagesdc.style.top = "0";
+        navbarpagesdc.style.width = '100%';
+        navbarpagesdc.style.zIndex  = '9';
+        navbarpagesdc.style.transition = '0.5s';
     }
     else{
-        navbarpagesdc.classList.remove('navback')
+        navbarpagesdc.classList.remove('navback');
     }
-})
+});
 
 // fin navbarpages effect 
 
 
 // card effect scroll
-var imgbackpngdc = document.getElementsByClassName('imgbackpngdc')[0]
+const imgbackpngdc = document.getElementsByClassName('imgbackpngdc')[0];
 imgbackpngdc.classList.add('dnone');
 
-window.addEventListener("scroll", function (){
-    let jssScroll = window.scrollY
+window.addEventListener('scroll', () => {
+    const jssScroll = window.scrollY;
     if (jssScroll >= 150) {
         imgbackpngdc.classList.remove('dnone');
         imgbackpngdc.classList.add('imgwhite');
@@ -84,10 +69,6 @@ window.addEventListener("scroll", function (){
         imgbackpngdc.classList.add('dnone');
         imgbackpngdc.classList.remove('imgwhite');
     }
-})
+});
 
 // fin card effect scroll
-// :
-// :
-// ::
-// :

--- a/public/pages/catepages/disney/disneypage.html
+++ b/public/pages/catepages/disney/disneypage.html
@@ -457,7 +457,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
         crossorigin="anonymous"></script>
-    <script src="disneypage.js"></script>
+    <script type="module" src="disneypage.js"></script>
 
 </body>
 

--- a/public/pages/catepages/disney/disneypage.js
+++ b/public/pages/catepages/disney/disneypage.js
@@ -1,27 +1,11 @@
+import { initCarousel } from '../../../utils.js';
+
 // cards carousel
-
-
-let cardContainers = [...document.querySelectorAll('.card-container')];
-let preBtns = [...document.querySelectorAll('.pre-btn')];
-let nxtBtns = [...document.querySelectorAll('.nxt-btn')];
-
-cardContainers.forEach((item, i) => {
-    let containerDimensions = item.getBoundingClientRect();
-    let containerWidth = containerDimensions.width;
-
-    nxtBtns[i].addEventListener('click', () => {
-        item.scrollLeft += containerWidth - 200;
-    })
-
-    preBtns[i].addEventListener('click', () => {
-        item.scrollLeft -= containerWidth + 200;
-    })
-})
+initCarousel('.card-container', '.pre-btn', '.nxt-btn');
 // fin cards carousel
 
 // disney page effect
-
-var bodydisney = document.querySelector('.bodydisney')
+const bodydisney = document.querySelector('.bodydisney');
 
 document.querySelector('.bodydisney').style.background = "url('../../../img/disneypage (11).gif') ";
 document.querySelector('.bodydisney').style.backgroundSize  = "100%";
@@ -30,7 +14,7 @@ document.querySelector('.bodydisney').style.backgroundColor   = " #131520";
 // bodymarvel.attributes.background.style.opacity    = " 0.5";
 bodydisney.style.backgroundAttachment    = " fixed";
 
-setInterval(function () {
+setInterval(() => {
 
     document.querySelector('.bodydisney').style.background = "url('../../../img/scale2.jfif') ";
     document.querySelector('.bodydisney').style.backgroundRepeat  = "no-repeat";
@@ -38,37 +22,35 @@ setInterval(function () {
     document.querySelector('.bodydisney').style.backgroundColor   = " #131520";
     bodydisney.style.backgroundAttachment    = " fixed";
 
-    
 }, 8300);
 // fin
 
 // navbar effect
-let navbarpagesdisney = document.querySelector('.navbarpagesdisney')
-window.addEventListener("scroll", function (){
-    let navScroll = window.scrollY
+const navbarpagesdisney = document.querySelector('.navbarpagesdisney');
+window.addEventListener('scroll', () => {
+    const navScroll = window.scrollY;
 
     if (navScroll >= 100) {
-        navbarpagesdisney.classList.add('navback')
-        navbarpagesdisney.style.position = "fixed"
-        // navbarpagesdisney.style.top = "0"
-        navbarpagesdisney.style.width = "100%"
-        navbarpagesdisney.style.zIndex  = "9"
-        navbarpagesdisney.style.transition = "0.5s"
+        navbarpagesdisney.classList.add('navback');
+        navbarpagesdisney.style.position = 'fixed';
+        // navbarpagesdisney.style.top = "0";
+        navbarpagesdisney.style.width = '100%';
+        navbarpagesdisney.style.zIndex  = '9';
+        navbarpagesdisney.style.transition = '0.5s';
     }
     else{
-        navbarpagesdisney.classList.remove('navback')
+        navbarpagesdisney.classList.remove('navback');
     }
-})
+});
 
-// fin navbarpages effect 
-
+// fin navbarpages effect
 
 // card effect scroll
-var imgbackpngdisney = document.getElementsByClassName('imgbackpngdisney')[0]
+const imgbackpngdisney = document.getElementsByClassName('imgbackpngdisney')[0];
 imgbackpngdisney.classList.add('dnone');
 
-window.addEventListener("scroll", function (){
-    let jssScroll = window.scrollY
+window.addEventListener('scroll', () => {
+    const jssScroll = window.scrollY;
     if (jssScroll >= 150) {
         imgbackpngdisney.classList.remove('dnone');
         imgbackpngdisney.classList.add('imgwhite');
@@ -77,4 +59,5 @@ window.addEventListener("scroll", function (){
         imgbackpngdisney.classList.add('dnone');
         imgbackpngdisney.classList.remove('imgwhite');
     }
-})
+});
+

--- a/public/pages/catepages/marvel/marvelpage.html
+++ b/public/pages/catepages/marvel/marvelpage.html
@@ -529,7 +529,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
         crossorigin="anonymous"></script>
-    <script src="marvelpage.js"></script>
+    <script type="module" src="marvelpage.js"></script>
 
 </body>
 

--- a/public/pages/catepages/marvel/marvelpage.js
+++ b/public/pages/catepages/marvel/marvelpage.js
@@ -1,26 +1,11 @@
+import { initCarousel } from '../../../utils.js';
+
 // cards carousel
-
-
-let cardContainers = [...document.querySelectorAll('.card-container')];
-let preBtns = [...document.querySelectorAll('.pre-btn')];
-let nxtBtns = [...document.querySelectorAll('.nxt-btn')];
-
-cardContainers.forEach((item, i) => {
-    let containerDimensions = item.getBoundingClientRect();
-    let containerWidth = containerDimensions.width;
-
-    nxtBtns[i].addEventListener('click', () => {
-        item.scrollLeft += containerWidth - 200;
-    })
-
-    preBtns[i].addEventListener('click', () => {
-        item.scrollLeft -= containerWidth + 200;
-    })
-})
+initCarousel('.card-container', '.pre-btn', '.nxt-btn');
 // fin cards carousel
 
 // page marvel
-var bodymarvel = document.querySelector('.bodymarvel')
+const bodymarvel = document.querySelector('.bodymarvel');
 
 document.querySelector('.bodymarvel').style.background = "url('../../../img/marvelpage (10).gif') ";
 document.querySelector('.bodymarvel').style.backgroundSize  = "100%";
@@ -29,7 +14,7 @@ document.querySelector('.bodymarvel').style.backgroundColor   = " #131520";
 // bodymarvel.attributes.background.style.opacity    = " 0.5";
 bodymarvel.style.backgroundAttachment    = " fixed";
 
-setInterval(function () {
+setInterval(() => {
 
     document.querySelector('.bodymarvel').style.background = "url('../../../img/scale.jfif') ";
     document.querySelector('.bodymarvel').style.backgroundRepeat  = "no-repeat";
@@ -37,60 +22,47 @@ setInterval(function () {
     document.querySelector('.bodymarvel').style.backgroundColor   = " #131520";
     bodymarvel.style.backgroundAttachment    = " fixed";
 
-    
 }, 8300);
 // fin page marvel
 
-// page disney
-
-
-
-// fin pages img affect
-
-// navbarpages effect 
-
-let navbarpages = document.querySelector('.navbarpages')
-window.addEventListener("scroll", function (){
-    let navScroll = window.scrollY
+// navbarpages effect
+const navbarpages = document.querySelector('.navbarpages');
+window.addEventListener('scroll', () => {
+    const navScroll = window.scrollY;
 
     if (navScroll >= 100) {
-        navbarpages.classList.add('navback')
-        navbarpages.style.position = "fixed"
-        // navbarpages.style.top = "0"
-        navbarpages.style.width = "100%"
-        navbarpages.style.zIndex  = "9"
-        navbarpages.style.transition = "0.5s"
+        navbarpages.classList.add('navback');
+        navbarpages.style.position = 'fixed';
+        // navbarpages.style.top = "0";
+        navbarpages.style.width = '100%';
+        navbarpages.style.zIndex  = '9';
+        navbarpages.style.transition = '0.5s';
     }
     else{
-        navbarpages.classList.remove('navback')
-        navbarpages.style.transition = "0.5s"
+        navbarpages.classList.remove('navback');
+        navbarpages.style.transition = '0.5s';
     }
-})
+});
 
-// fin navbarpages effect 
-
+// fin navbarpages effect
 
 // card effect scroll
-var imgbackpng = document.getElementsByClassName('imgbackpng')[0]
+const imgbackpng = document.getElementsByClassName('imgbackpng')[0];
 imgbackpng.classList.add('dnone');
 
-window.addEventListener("scroll", function (){
-    let jssScroll = window.scrollY
+window.addEventListener('scroll', () => {
+    const jssScroll = window.scrollY;
     if (jssScroll >= 150) {
         imgbackpng.classList.remove('dnone');
         imgbackpng.classList.add('imgwhite');
-        imgbackpng.style.transition = "0.5s"
+        imgbackpng.style.transition = '0.5s';
     }
     else{
         imgbackpng.classList.add('dnone');
         imgbackpng.classList.remove('imgwhite');
-        imgbackpng.style.transition = "1s"
-
+        imgbackpng.style.transition = '1s';
     }
-})
+});
 
 // fin card effect scroll
-// :
-// :
-// ::
-// :
+

--- a/public/pages/catepages/pixar/pixarpage.html
+++ b/public/pages/catepages/pixar/pixarpage.html
@@ -457,7 +457,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
         crossorigin="anonymous"></script>
-    <script src="pixarpage.js"></script>
+    <script type="module" src="pixarpage.js"></script>
 
 </body>
 

--- a/public/pages/catepages/pixar/pixarpage.js
+++ b/public/pages/catepages/pixar/pixarpage.js
@@ -1,27 +1,11 @@
+import { initCarousel } from '../../../utils.js';
+
 // cards carousel
-
-
-let cardContainers = [...document.querySelectorAll('.card-container')];
-let preBtns = [...document.querySelectorAll('.pre-btn')];
-let nxtBtns = [...document.querySelectorAll('.nxt-btn')];
-
-cardContainers.forEach((item, i) => {
-    let containerDimensions = item.getBoundingClientRect();
-    let containerWidth = containerDimensions.width;
-
-    nxtBtns[i].addEventListener('click', () => {
-        item.scrollLeft += containerWidth - 200;
-    })
-
-    preBtns[i].addEventListener('click', () => {
-        item.scrollLeft -= containerWidth + 200;
-    })
-})
+initCarousel('.card-container', '.pre-btn', '.nxt-btn');
 // fin cards carousel
 
 // disney page effect
-
-var bodypixar = document.querySelector('.bodypixar')
+const bodypixar = document.querySelector('.bodypixar');
 
 document.querySelector('.bodypixar').style.background = "url('../../../img/pixarpage (12).gif') ";
 document.querySelector('.bodypixar').style.backgroundSize  = "100%";
@@ -30,7 +14,7 @@ document.querySelector('.bodypixar').style.backgroundColor   = " #131520";
 // bodymarvel.attributes.background.style.opacity    = " 0.5";
 bodypixar.style.backgroundAttachment    = " fixed";
 
-setInterval(function () {
+setInterval(() => {
 
     document.querySelector('.bodypixar').style.background = "url('../../../img/scale3.jfif') ";
     document.querySelector('.bodypixar').style.backgroundRepeat  = "no-repeat";
@@ -38,39 +22,35 @@ setInterval(function () {
     document.querySelector('.bodypixar').style.backgroundColor   = " #131520";
     bodypixar.style.backgroundAttachment    = " fixed";
 
-    
 }, 8300);
 // fin
 
 // navbar effect
-
-
-let navbarpagespixar = document.querySelector('.navbarpagespixar')
-window.addEventListener("scroll", function (){
-    let navScroll = window.scrollY
+const navbarpagespixar = document.querySelector('.navbarpagespixar');
+window.addEventListener('scroll', () => {
+    const navScroll = window.scrollY;
 
     if (navScroll >= 100) {
-        navbarpagespixar.classList.add('navback')
-        navbarpagespixar.style.position = "fixed"
-        // navbarpagespixar.style.top = "0"
-        navbarpagespixar.style.width = "100%"
-        navbarpagespixar.style.zIndex  = "9"
-        navbarpagespixar.style.transition = "0.5s"
+        navbarpagespixar.classList.add('navback');
+        navbarpagespixar.style.position = 'fixed';
+        // navbarpagespixar.style.top = "0";
+        navbarpagespixar.style.width = '100%';
+        navbarpagespixar.style.zIndex  = '9';
+        navbarpagespixar.style.transition = '0.5s';
     }
     else{
-        navbarpagespixar.classList.remove('navback')
+        navbarpagespixar.classList.remove('navback');
     }
-})
+});
 
-// fin navbarpages effect 
-
+// fin navbarpages effect
 
 // card effect scroll
-var imgbackpngpixar = document.getElementsByClassName('imgbackpngpixar')[0]
+const imgbackpngpixar = document.getElementsByClassName('imgbackpngpixar')[0];
 imgbackpngpixar.classList.add('dnone');
 
-window.addEventListener("scroll", function (){
-    let jssScroll = window.scrollY
+window.addEventListener('scroll', () => {
+    const jssScroll = window.scrollY;
     if (jssScroll >= 150) {
         imgbackpngpixar.classList.remove('dnone');
         imgbackpngpixar.classList.add('imgwhite');
@@ -79,4 +59,5 @@ window.addEventListener("scroll", function (){
         imgbackpngpixar.classList.add('dnone');
         imgbackpngpixar.classList.remove('imgwhite');
     }
-})
+});
+

--- a/public/pages/search/search.html
+++ b/public/pages/search/search.html
@@ -734,7 +734,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
         crossorigin="anonymous"></script>
-    <script src="../../main.js"></script>
+    <script type="module" src="../../main.js"></script>
    <!-- Site footer -->
   <footer class="site-footer mt-5">
     <div class="container">

--- a/public/utils.js
+++ b/public/utils.js
@@ -1,0 +1,15 @@
+export const initCarousel = (containerSelector, prevBtnSelector, nextBtnSelector) => {
+    const cardContainers = [...document.querySelectorAll(containerSelector)];
+    const preBtns = [...document.querySelectorAll(prevBtnSelector)];
+    const nxtBtns = [...document.querySelectorAll(nextBtnSelector)];
+
+    cardContainers.forEach((item, i) => {
+        const { width: containerWidth } = item.getBoundingClientRect();
+        nxtBtns[i].addEventListener('click', () => {
+            item.scrollLeft += containerWidth - 200;
+        });
+        preBtns[i].addEventListener('click', () => {
+            item.scrollLeft -= containerWidth + 200;
+        });
+    });
+};


### PR DESCRIPTION
## Summary
- centralize carousel logic in new `utils.js` module
- modernize `main.js` and category page scripts with `const`/`let`, arrow functions, and `forEach`
- load scripts as ES modules via `type="module"` in HTML

## Testing
- `node --version`
- `node --input-type=module -e "import('./public/utils.js').then(() => console.log('utils loaded')).catch(e => console.error(e))"`


------
https://chatgpt.com/codex/tasks/task_e_6897d59d4d54832bb7fddfa23baa53f5